### PR TITLE
Add event when saving drafts and make dw_locktimer reusable by plugin JS

### DIFF
--- a/inc/Action/Preview.php
+++ b/inc/Action/Preview.php
@@ -14,7 +14,7 @@ class Preview extends Edit {
     /** @inheritdoc */
     public function preProcess() {
         header('X-XSS-Protection: 0');
-        $this->savedraft();
+        saveDraft();
         parent::preProcess();
     }
 
@@ -24,35 +24,4 @@ class Preview extends Edit {
         html_edit();
         html_show($TEXT);
     }
-
-    /**
-     * Saves a draft on preview
-     */
-    protected function savedraft() {
-        global $INFO;
-        global $ID;
-        global $INPUT;
-        global $conf;
-
-        if(!$conf['usedraft']) return;
-        if(!$INPUT->post->has('wikitext')) return;
-
-        // ensure environment (safeguard when used via AJAX)
-        assert(isset($INFO['client']), 'INFO.client should have been set');
-        assert(isset($ID), 'ID should have been set');
-
-        $draft = array(
-            'id' => $ID,
-            'prefix' => substr($INPUT->post->str('prefix'), 0, -1),
-            'text' => $INPUT->post->str('wikitext'),
-            'suffix' => $INPUT->post->str('suffix'),
-            'date' => $INPUT->post->int('date'),
-            'client' => $INFO['client'],
-        );
-        $cname = getCacheName($draft['client'] . $ID, '.draft');
-        if(io_saveFile($cname, serialize($draft))) {
-            $INFO['draft'] = $cname;
-        }
-    }
-
 }

--- a/inc/Ajax.php
+++ b/inc/Ajax.php
@@ -140,22 +140,8 @@ class Ajax {
             echo 1;
         }
 
-        if($conf['usedraft'] && $INPUT->post->str('wikitext')) {
-            $client = $_SERVER['REMOTE_USER'];
-            if(!$client) $client = clientIP(true);
-
-            $draft = array(
-                'id' => $ID,
-                'prefix' => substr($INPUT->post->str('prefix'), 0, -1),
-                'text' => $INPUT->post->str('wikitext'),
-                'suffix' => $INPUT->post->str('suffix'),
-                'date' => $INPUT->post->int('date'),
-                'client' => $client,
-            );
-            $cname = getCacheName($draft['client'] . $ID, '.draft');
-            if(io_saveFile($cname, serialize($draft))) {
-                echo $lang['draftdate'] . ' ' . dformat();
-            }
+        if (saveDraft()) {
+            echo $lang['draftdate'] . ' ' . dformat();
         }
 
     }

--- a/inc/common.php
+++ b/inc/common.php
@@ -1450,10 +1450,12 @@ function saveDraft()
     );
     $event = new \Doku_Event('COMMON_DRAFT_SAVE', $draft);
     if ($event->advise_before()) {
-        if (io_saveFile($draft['cname'], serialize($draft))) {
-            $draft['hasBeenSaved'] = true;
+        $draft['hasBeenSaved'] = io_saveFile($draft['cname'], serialize($draft));
+        if ($draft['hasBeenSaved']) {
             $INFO['draft'] = $draft['cname'];
         }
+    } else {
+        $draft['hasBeenSaved'] = false;
     }
 
     $event->advise_after();

--- a/inc/html.php
+++ b/inc/html.php
@@ -1833,10 +1833,10 @@ function html_edit(){
     <div class="editBox" role="application">
 
     <div class="toolbar group">
-        <div id="draft__status" class="draft__status"><?php if(!empty($INFO['draft'])) echo $lang['draftdate'].' '.dformat();?></div>
         <div id="tool__bar" class="tool__bar"><?php if ($wr && $data['media_manager']){?><a href="<?php echo DOKU_BASE?>lib/exe/mediamanager.php?ns=<?php echo $INFO['namespace']?>"
             target="_blank"><?php echo $lang['mediaselect'] ?></a><?php }?></div>
     </div>
+    <div id="draft__status" class="draft__status"><?php if(!empty($INFO['draft'])) echo $lang['draftdate'].' '.dformat();?></div>
     <?php
 
     html_form('edit', $form);

--- a/lib/scripts/locktimer.js
+++ b/lib/scripts/locktimer.js
@@ -59,7 +59,11 @@ var dw_locktimer = {
     },
 
     /**
-     * Add a callback the gets executed the post to renew the lock / save the draft returns successfully
+     * Add a callback that is executed when the post request to renew the lock and save the draft returns successfully
+     *
+     * If the user types into the edit-area, then dw_locktimer will regularly send a post request to the DokuWiki server
+     * to extend the page's lock and update the draft. When this request returns successfully, then the draft__status
+     * is updated. This method can be used to add further callbacks to be executed at that moment.
      *
      * @param {function} callback the only param is the data returned by the server
      */

--- a/lib/scripts/locktimer.js
+++ b/lib/scripts/locktimer.js
@@ -43,8 +43,6 @@ var dw_locktimer = {
             return;
         }
 
-        dw_locktimer.callbacks.push(dw_locktimer.refreshed);
-
         // register refresh event
         $edit.keypress(dw_locktimer.refresh);
         // start timer
@@ -145,3 +143,4 @@ var dw_locktimer = {
         dw_locktimer.reset();
     }
 };
+dw_locktimer.callbacks.push(dw_locktimer.refreshed);

--- a/lib/scripts/locktimer.js
+++ b/lib/scripts/locktimer.js
@@ -8,6 +8,12 @@ var dw_locktimer = {
     lasttime: null,
     msg: LANG.willexpire,
     pageid: '',
+    fieldsToSaveAsDraft: [
+        'input[name=prefix]',
+        'textarea[name=wikitext]',
+        'input[name=suffix]',
+        'input[name=date]',
+    ],
 
     /**
      * Initialize the lock timer
@@ -40,6 +46,13 @@ var dw_locktimer = {
         $edit.keypress(dw_locktimer.refresh);
         // start timer
         dw_locktimer.reset();
+    },
+
+    /**
+     * Add another field of the editform to be posted to the server when a draft is saved
+     */
+    addField: function(selector) {
+        dw_locktimer.fieldsToSaveAsDraft.push(selector);
     },
 
     /**
@@ -84,10 +97,7 @@ var dw_locktimer = {
 
         // POST everything necessary for draft saving
         if(dw_locktimer.draft && jQuery('#dw__editform').find('textarea[name=wikitext]').length > 0){
-            params += jQuery('#dw__editform').find('input[name=prefix], ' +
-                                                   'textarea[name=wikitext], ' +
-                                                   'input[name=suffix], ' +
-                                                   'input[name=date]').serialize();
+            params += jQuery('#dw__editform').find(dw_locktimer.fieldsToSaveAsDraft.join(', ')).serialize();
         }
 
         jQuery.post(

--- a/lib/scripts/locktimer.js
+++ b/lib/scripts/locktimer.js
@@ -14,6 +14,7 @@ var dw_locktimer = {
         'input[name=suffix]',
         'input[name=date]',
     ],
+    callbacks: [],
 
     /**
      * Initialize the lock timer
@@ -42,6 +43,8 @@ var dw_locktimer = {
             return;
         }
 
+        dw_locktimer.callbacks.push(dw_locktimer.refreshed);
+
         // register refresh event
         $edit.keypress(dw_locktimer.refresh);
         // start timer
@@ -53,6 +56,15 @@ var dw_locktimer = {
      */
     addField: function(selector) {
         dw_locktimer.fieldsToSaveAsDraft.push(selector);
+    },
+
+    /**
+     * Add a callback the gets executed the post to renew the lock / save the draft returns successfully
+     *
+     * @param {function} callback the only param is the data returned by the server
+     */
+    addRefreshCallback: function(callback) {
+        dw_locktimer.callbacks.push(callback);
     },
 
     /**
@@ -103,9 +115,15 @@ var dw_locktimer = {
         jQuery.post(
             DOKU_BASE + 'lib/exe/ajax.php',
             params,
-            dw_locktimer.refreshed,
+            null,
             'html'
-        );
+        ).done(function dwLocktimerRefreshDoneHandler(data) {
+            dw_locktimer.callbacks.forEach(
+                function foo(callback) {
+                    callback(data);
+                }
+            );
+        });
         dw_locktimer.lasttime = now;
     },
 

--- a/lib/tpl/dokuwiki/css/_edit.css
+++ b/lib/tpl/dokuwiki/css/_edit.css
@@ -12,6 +12,7 @@
 /*____________ toolbar ____________*/
 
 .dokuwiki div.toolbar {
+    display: inline-block;
     margin-bottom: .5em;
 }
 #draft__status {


### PR DESCRIPTION
Some plugins that completely replace the editor may still want to have their edit-progress be saved as drafts by the default DokuWiki draft-saving process.

- refactor the server-side draft saving to happen only at a single place and trigger a new event: `COMMON_DRAFT_SAVE`
- extend the the `dw_locktimer` to allow posting further fields to the server when saving drafts in the background while editing
- move `#draft__status` out of the toolbar `<div>` so we can hide the toolbar without hiding the draft status