### PR TITLE
Add option 'modPassPlain' to send plaintext password updates to LDAP server

### DIFF
--- a/lib/plugins/authldap/auth.php
+++ b/lib/plugins/authldap/auth.php
@@ -365,8 +365,12 @@ class auth_plugin_authldap extends AuthPlugin
         }
 
         // Generate the salted hashed password for LDAP
-        $phash = new PassHash();
-        $hash = $phash->hash_ssha($changes['pass']);
+        if ($this->getConf('modPassPlain')) {
+            $hash = $changes['pass'];
+        } else {
+            $phash = new PassHash();
+            $hash = $phash->hash_ssha($changes['pass']);
+        }
 
         // change the password
         if (!@ldap_mod_replace($this->con, $dn, ['userpassword' => $hash])) {

--- a/lib/plugins/authldap/conf/default.php
+++ b/lib/plugins/authldap/conf/default.php
@@ -20,4 +20,5 @@ $conf['userkey']    = 'uid';
 $conf['groupkey']   = 'cn';
 $conf['debug']      = 0;
 $conf['modPass']    = 1;
+$conf['modPassPlain'] = 0;
 $conf['attributes'] = array();

--- a/lib/plugins/authldap/conf/metadata.php
+++ b/lib/plugins/authldap/conf/metadata.php
@@ -21,3 +21,4 @@ $meta['userkey']     = array('string','_caution' => 'danger');
 $meta['groupkey']    = array('string','_caution' => 'danger');
 $meta['debug']       = array('onoff','_caution' => 'security');
 $meta['modPass']     = array('onoff');
+$meta['modPassPlain']= array('onoff','_caution' => 'security');

--- a/lib/plugins/authldap/lang/en/settings.php
+++ b/lib/plugins/authldap/lang/en/settings.php
@@ -17,6 +17,7 @@ $lang['groupscope']  = 'Limit search scope for group search';
 $lang['userkey']     = 'Attribute denoting the username; must be consistent to userfilter.';
 $lang['groupkey']    = 'Group membership from any user attribute (instead of standard AD groups) e.g. group from department or telephone number';
 $lang['modPass']     = 'Can the LDAP password be changed via dokuwiki?';
+$lang['modPassPlain']= 'Send password updates in plain text to the LDAP server (rather than salt and hash them with the configured algorithm before transmission)?';
 $lang['debug']       = 'Display additional debug information on errors';
 
 


### PR DESCRIPTION
This adds an additional option `modPassPlain` to the authldap plugin. Sending a password update to an LDAP server in plaintext is useful is a few cases:

- The hashing algorithm and/or format is not available in dokuwiki (e.g. RedHat's pbkdf2_sha256 format, the default for 389ds and RHDS)
- A password policy is enabled on the server. This can't be enforced when sending hashed passwords
- Sending hashed passwords is disabled or only available to privileged accounts (password managers, directory managers) on the LDAP server (e.g. `nsslapd-allow-hashed-passwords` is off per default on 389ds and RHDS). Using plaintext passwords allows binding with a service account or as user with less privileges
- The number of rounds is (e.g. for pbkdf2_sha256) is either unknown or cumbersome to manage in dokuwiki (e.g. 389ds dynamically sets the number of rounds depending on hardware capabilities)

This obviously should only be used via a secure or private communication channel (ldaps, starttls, ldapi).