### PR TITLE
make $fnid a full writeable static property for plugins to manipulate

### DIFF
--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -46,6 +46,9 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
     /** @var array list of allowed URL schemes */
     protected $schemes = null;
 
+    /** @var int counts the number of footnotes to avoid collisions even if multiple docs are parsed. */
+    public static $fnid = 0;
+
     /**
      * Register a new edit section range
      *
@@ -433,10 +436,8 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
      * @author Andreas Gohr
      */
     public function footnote_close() {
-        /** @var $fnid int takes track of seen footnotes, assures they are unique even across multiple docs FS#2841 */
-        static $fnid = 0;
         // assign new footnote id (we start at 1)
-        $fnid++;
+        self::$fnid++;
 
         // recover footnote into the stack and restore old content
         $footnote    = $this->doc;
@@ -448,14 +449,14 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
 
         if($i === false) {
             // its a new footnote, add it to the $footnotes array
-            $this->footnotes[$fnid] = $footnote;
+            $this->footnotes[self::$fnid] = $footnote;
         } else {
             // seen this one before, save a placeholder
-            $this->footnotes[$fnid] = "@@FNT".($i);
+            $this->footnotes[self::$fnid] = "@@FNT".($i);
         }
 
         // output the footnote reference and link
-        $this->doc .= '<sup><a href="#fn__'.$fnid.'" id="fnt__'.$fnid.'" class="fn_top">'.$fnid.')</a></sup>';
+        $this->doc .= '<sup><a href="#fn__'.self::$fnid.'" id="fnt__'.self::$fnid.'" class="fn_top">'.self::$fnid.')</a></sup>';
     }
 
     /**

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -456,7 +456,9 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
         }
 
         // output the footnote reference and link
-        $this->doc .= '<sup><a href="#fn__'.self::$fnid.'" id="fnt__'.self::$fnid.'" class="fn_top">'.self::$fnid.')</a></sup>';
+        $this->doc .= vsprintf(
+            '<sup><a href="#fn__%d" id="fnt__%d" class="fn_top">%d)</a></sup>',
+            array_fill(0, 3, self::$fnid));
     }
 
     /**


### PR DESCRIPTION
I'd love to be told that there are other ways to do this, but I was trying to use footnotes within an infobox from a [templater plugin](https://github.com/WaltWh/templater2) and the original version put the footnotes directly under infobox, forcing all other content down below the footnotes - a reasonable behavior for embedding part of another page, but not great for an infobox.

I managed to make a version of the plugin that stripped out the footnotes, but then the footnote was just lost.

I managed to make a version where the footnotes exist at the bottom of the page and are linked correctly, but e.g. a template with 2 footnotes resulted in footnotes 3 & 4, rather than 1 & 2.

The only way I could find for the actual desired behavior was to make this change to the core dokuwiki code.