### PR TITLE
output full path when initializing savedir path fails

### DIFF
--- a/_test/tests/inc/init_fullpath.test.php
+++ b/_test/tests/inc/init_fullpath.test.php
@@ -15,6 +15,7 @@ class init_fullpath_test extends DokuWikiTest {
                         '/foo/./bar/baz' => '/foo/bar/baz',
                         '/foo/bar/..' => '/foo',
                         '/foo/bar/../../../baz' => '/baz',
+                        '/foo/bar//baz' => '/foo/bar/baz',
 
                         'foo/bar/baz' => '/absolute/path/foo/bar/baz',
                         'foo//bar/baz' => '/absolute/path/foo/bar/baz',
@@ -48,6 +49,7 @@ class init_fullpath_test extends DokuWikiTest {
                         'c:foo/./bar/baz' => 'c:/foo/bar/baz',
                         'c:foo/bar/..' => 'c:/foo',
                         'c:foo/bar/../../../baz' => 'c:/baz',
+                        'c:foo/bar//baz' => 'c:/foo/bar/baz',
 
                         'c:/foo/bar/baz' => 'c:/foo/bar/baz',
                         'c:/foo//bar/baz' => 'c:/foo/bar/baz',
@@ -62,6 +64,7 @@ class init_fullpath_test extends DokuWikiTest {
                         'c:\\foo\\.\\bar\\baz' => 'c:/foo/bar/baz',
                         'c:\\foo\\bar\\..' => 'c:/foo',
                         'c:\\foo\\bar\\..\\..\\..\\baz' => 'c:/baz',
+                        'c:\\foo\\bar\\\\baz' => 'c:/foo/bar/baz',
 
                         '\\\\server\\share/foo/bar/baz' => '\\\\server\\share/foo/bar/baz',
                         '\\\\server\\share/foo//bar/baz' => '\\\\server\\share/foo/bar/baz',

--- a/inc/init.php
+++ b/inc/init.php
@@ -289,11 +289,13 @@ function init_paths(){
     foreach($paths as $c => $p) {
         $path = empty($conf[$c]) ? $conf['savedir'].'/'.$p : $conf[$c];
         $conf[$c] = init_path($path);
-        if(empty($conf[$c]))
+        if(empty($conf[$c])) {
+            $path = fullpath($path);
             nice_die("The $c ('$p') at $path is not found, isn't accessible or writable.
                 You should check your config and permission settings.
                 Or maybe you want to <a href=\"install.php\">run the
                 installer</a>?");
+        }
     }
 
     // path to old changelog only needed for upgrading


### PR DESCRIPTION
This will not only clean up double slashes etc. as mentioned in #3903 but will also output the full canonical path (starting at the filesystem root) when showing an error on initializing the savedir paths. This should make it easier to understand which path DokuWiki is trying to access exactly.