### PR TITLE
Fixes "Undefined array key" when deleting a media in use on PHP 8.1

### DIFF
--- a/lib/exe/mediamanager.php
+++ b/lib/exe/mediamanager.php
@@ -116,7 +116,7 @@ use dokuwiki\Extension\Event;
             }
             msg($msg,1);
         } elseif ($res & DOKU_MEDIA_INUSE) {
-            if(!$conf['refshow']) {
+            if(!isset($conf['refshow']) || !$conf['refshow']) {
                 msg(sprintf($lang['mediainuse'],noNS($DEL)),0);
             }
         } else {


### PR DESCRIPTION
Fixes "Undefined array key" when deleting a media in use on PHP 8.1