### PR TITLE
Fix old revisions skipping one revision

### DIFF
--- a/inc/Action/Revisions.php
+++ b/inc/Action/Revisions.php
@@ -23,6 +23,6 @@ class Revisions extends AbstractAction
     public function tplContent()
     {
         global $INFO, $INPUT;
-        (new Ui\PageRevisions($INFO['id']))->show($INPUT->int('first'));
+        (new Ui\PageRevisions($INFO['id']))->show($INPUT->int('first', -1));
     }
 }

--- a/inc/Ui/MediaRevisions.php
+++ b/inc/Ui/MediaRevisions.php
@@ -47,13 +47,13 @@ class MediaRevisions extends Revisions
      * @param int $first  skip the first n changelog lines
      * @return void
      */
-    public function show($first = 0)
+    public function show($first = -1)
     {
         global $lang;
         $changelog =& $this->changelog;
 
         // get revisions, and set correct pagination parameters (first, hasNext)
-        if ($first === null) $first = 0;
+        if ($first === null) $first = -1;
         $hasNext = false;
         $revisions = $this->getRevisions($first, $hasNext);
 

--- a/inc/Ui/PageRevisions.php
+++ b/inc/Ui/PageRevisions.php
@@ -45,13 +45,13 @@ class PageRevisions extends Revisions
      * @param int $first  skip the first n changelog lines
      * @return void
      */
-    public function show($first = 0)
+    public function show($first = -1)
     {
         global $lang, $REV;
         $changelog =& $this->changelog;
 
         // get revisions, and set correct pagination parameters (first, hasNext)
-        if ($first === null) $first = 0;
+        if ($first === null) $first = -1;
         $hasNext = false;
         $revisions = $this->getRevisions($first, $hasNext);
 

--- a/inc/Ui/Revisions.php
+++ b/inc/Ui/Revisions.php
@@ -8,6 +8,9 @@ use dokuwiki\ChangeLog\ChangeLog;
  * DokuWiki Revisions Interface
  * parent class of PageRevisions and MediaRevisions
  *
+ * Note: navigation starts from -1, not 0. This is because our Revision management starts old revisions at 0 and
+ * will return the current revision only if the revisions starting at -1 are requested.
+ *
  * @package dokuwiki\Ui
  */
 abstract class Revisions extends Ui
@@ -21,7 +24,7 @@ abstract class Revisions extends Ui
     /**
      * Revisions Ui constructor
      *
-     * @param string $id  page id or media id
+     * @param string $id page id or media id
      */
     public function __construct($id)
     {
@@ -37,7 +40,7 @@ abstract class Revisions extends Ui
     /**
      * Get revisions, and set correct pagination parameters (first, hasNext)
      *
-     * @param int  $first
+     * @param int $first
      * @param bool $hasNext
      * @return array  revisions to be shown in a paginated list
      * @see also https://www.dokuwiki.org/devel:changelog
@@ -53,24 +56,15 @@ abstract class Revisions extends Ui
         if (!$currentRevInfo) return $revisions;
 
         $num = $conf['recent'];
-        if ($first == 0) {
-            // add external or existing last revision that is excluded from $changelog->getRevisions()
-            if (array_key_exists('timestamp', $currentRevInfo) || (
-                $currentRevInfo['type'] != DOKU_CHANGE_TYPE_DELETE &&
-                $currentRevInfo['date'] == $changelog->lastRevision() )
-            ) {
-                $revisions[] = $currentRevInfo;
-                $num = $num - 1;
-            }
-        }
+
         /* we need to get one additional log entry to be able to
          * decide if this is the last page or is there another one.
          * see also Ui\Recent::getRecents()
          */
         $revlist = $changelog->getRevisions($first, $num + 1);
-        if (count($revlist) == 0 && $first > 0) {
+        if (count($revlist) == 0 && $first > -1) {
             // resets to zero if $first requested a too high number
-            $first = 0;
+            $first = -1;
             return $this->getRevisions($first, $hasNext);
         }
 
@@ -91,7 +85,7 @@ abstract class Revisions extends Ui
     /**
      * Navigation buttons for Pagination (prev/next)
      *
-     * @param int  $first
+     * @param int $first
      * @param bool $hasNext
      * @param callable $callback returns array of hidden fields for the form button
      * @return string html
@@ -102,18 +96,18 @@ abstract class Revisions extends Ui
 
         $html = '<div class="pagenav">';
         $last = $first + $conf['recent'];
-        if ($first > 0) {
-            $first = max($first - $conf['recent'], 0);
-            $html.= '<div class="pagenav-prev">';
-            $html.= html_btn('newer', $this->id, "p", $callback($first));
-            $html.= '</div>';
+        if ($first > -1) {
+            $first = max($first - $conf['recent'], -1);
+            $html .= '<div class="pagenav-prev">';
+            $html .= html_btn('newer', $this->id, "p", $callback($first));
+            $html .= '</div>';
         }
         if ($hasNext) {
-            $html.= '<div class="pagenav-next">';
-            $html.= html_btn('older', $this->id, "n", $callback($last));
-            $html.= '</div>';
+            $html .= '<div class="pagenav-next">';
+            $html .= html_btn('older', $this->id, "n", $callback($last));
+            $html .= '</div>';
         }
-        $html.= '</div>';
+        $html .= '</div>';
         return $html;
     }
 

--- a/inc/html.php
+++ b/inc/html.php
@@ -315,7 +315,7 @@ function html_locked() {
  * @param string $media_id id of media, or empty for current page
  * @deprecated 2020-07-18
  */
-function html_revisions($first = 0, $media_id = '') {
+function html_revisions($first = -1, $media_id = '') {
     dbg_deprecated(PageRevisions::class .'::show()');
     if ($media_id) {
         (new dokuwiki\Ui\MediaRevisions($media_id))->show($first);

--- a/inc/media.php
+++ b/inc/media.php
@@ -1004,7 +1004,7 @@ function media_tab_history($image, $ns, $auth=null) {
         if ($do == 'diff'){
             (new dokuwiki\Ui\MediaDiff($image))->show(); //media_diff($image, $ns, $auth);
         } else {
-            $first = $INPUT->int('first');
+            $first = $INPUT->int('first',-1);
             (new dokuwiki\Ui\MediaRevisions($image))->show($first);
         }
     } else {


### PR DESCRIPTION
This changes the UI to start counting at -1, which will instruct the Revision Management to prepend the current revision to the list of old revisions returned. This way no special handling for the current revision has to be done in the UI class anymore and paging works naturally.

Fixes #3897