### PR TITLE
Fix password input field name (deletion of user profile)

### DIFF
--- a/inc/Ui/UserProfile.php
+++ b/inc/Ui/UserProfile.php
@@ -107,7 +107,7 @@ class UserProfile extends Ui
             if ($conf['profileconfirm']) {
                 $form->addHTML("<br>\n");
                 $attr = array('size' => '50', 'required' => 'required');
-                $input = $form->addPasswordInput('oldppass', $lang['oldpass'])->attrs($attr)
+                $input = $form->addPasswordInput('oldpass', $lang['oldpass'])->attrs($attr)
                     ->addClass('edit');
                 $input->getLabel()->attr('class', 'block');
                 $form->addHTML("<br>\n");


### PR DESCRIPTION
Deletion of a user profile does not work for me. The action is always refused due to incorrect password.

After fixing the input field name, it worked for me. Is this just a typo or am I missing any side effects?