### PR TITLE
support SVG logo in dokuwiki template

### DIFF
--- a/lib/tpl/dokuwiki/css/design.less
+++ b/lib/tpl/dokuwiki/css/design.less
@@ -35,6 +35,7 @@
         img {
             float: left;
             margin-right: .5em;
+            height: 64px;
         }
 
         span {

--- a/lib/tpl/dokuwiki/images/dokuwiki.svg
+++ b/lib/tpl/dokuwiki/images/dokuwiki.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 128.17 128.04">
+  <defs>
+    <linearGradient id="a">
+      <stop stop-color="#d69c00" offset="0"/>
+      <stop stop-color="#ffe658" offset="1"/>
+    </linearGradient>
+    <linearGradient id="n" x1="192.04" x2="263.67" y1="262.26" y2="262.26" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#00a423" offset="0"/>
+      <stop stop-color="#00b427" offset="1"/>
+    </linearGradient>
+    <linearGradient id="p" x1="191.75" x2="255.66" y1="258.92" y2="258.92" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#00b62b" offset="0"/>
+      <stop stop-color="#a1d784" offset="1"/>
+    </linearGradient>
+    <linearGradient id="m" x1="184.07" x2="201.41" y1="246.36" y2="246.36" gradientUnits="userSpaceOnUse" xlink:href="#a"/>
+    <linearGradient id="d" x1="162.76" x2="240.85" y1="184.99" y2="289.5" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ede1ae" offset="0"/>
+      <stop stop-color="#fefdfa" offset="1"/>
+    </linearGradient>
+    <linearGradient id="b" x1="140.16" x2="136.14" y1="303.79" y2="195.87" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#fbf6f0" offset="0"/>
+      <stop stop-color="#e9dac7" offset="1"/>
+    </linearGradient>
+    <linearGradient id="c" x1="286.16" x2="185.81" y1="262.29" y2="172.32" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#fbfaf9" offset="0"/>
+      <stop stop-color="#e9dac7" offset="1"/>
+    </linearGradient>
+    <linearGradient id="h" x1="213.97" x2="244.79" y1="220.07" y2="265.4" gradientUnits="userSpaceOnUse">
+      <stop stop-opacity=".173" offset="0"/>
+      <stop stop-color="#c7cec2" stop-opacity="0" offset="1"/>
+    </linearGradient>
+    <linearGradient id="l" x1="184.31" x2="224.67" y1="241.53" y2="307.53" gradientUnits="userSpaceOnUse">
+      <stop stop-opacity=".173" offset="0"/>
+      <stop stop-color="#c7cec2" stop-opacity="0" offset="1"/>
+    </linearGradient>
+    <linearGradient id="e" x1="202.42" x2="206.06" y1="222.05" y2="210.36" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#e32525" stop-opacity=".816" offset="0"/>
+      <stop stop-color="#e32525" stop-opacity=".571" offset="1"/>
+    </linearGradient>
+    <linearGradient id="f" x1="248.62" x2="251.64" y1="234.52" y2="213.12" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#25901b" stop-opacity=".837" offset="0"/>
+      <stop stop-color="#25901b" stop-opacity=".378" offset="1"/>
+    </linearGradient>
+    <linearGradient id="g" x1="275.72" x2="255.68" y1="251.56" y2="217.94" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#3a9030" stop-opacity=".837" offset="0"/>
+      <stop stop-color="#3d9c32" stop-opacity=".796" offset="1"/>
+    </linearGradient>
+    <linearGradient id="k" x1="219.66" x2="277.88" y1="192.73" y2="192.73" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ce411e" offset="0"/>
+      <stop stop-color="#ecad8d" offset="1"/>
+    </linearGradient>
+    <linearGradient id="j" x1="219.21" x2="286.23" y1="189.02" y2="189.02" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#8f2a15" offset="0"/>
+      <stop stop-color="#c8381b" offset="1"/>
+    </linearGradient>
+    <radialGradient id="o" cx="257.41" cy="274.64" r="7.144" gradientTransform="matrix(1 0 0 1.6314 0 -173.4)" gradientUnits="userSpaceOnUse" xlink:href="#a"/>
+    <radialGradient id="i" cx="224.41" cy="212.8" r="8.681" gradientTransform="matrix(1 0 0 .98418 0 3.367)" gradientUnits="userSpaceOnUse" xlink:href="#a"/>
+  </defs>
+  <g fill-rule="evenodd" stroke="#000">
+    <path transform="matrix(.98991 -.14067 .20106 .97564 -158.095 -157.774)" d="m120.22 196.44 70.907-.792-2.403 109.05-71.718.373 3.214-108.63z" fill="url(#b)" stroke-width=".722"/>
+    <path d="m179.2 182.09 79.842-19.517 26.614 101.72-82.503 21.587L179.2 182.09z" fill="url(#c)" transform="matrix(.99993 0 0 .99598 -158.095 -157.774)"/>
+    <path transform="matrix(.99561 -.09253 .08102 .9927 -158.095 -157.774)" d="m159.01 181.74 85.586.534v110.47l-84.534-2.513-1.052-108.5z" fill="url(#d)" stroke-width="1.004"/>
+  </g>
+  <path d="M29.106 38.471 27.179 18.46l5.325-.508.226 2.353-2.47.236 1.474 15.305 2.47-.236.226 2.354-5.324.508m7.313-.698L34.492 17.76l5.325-.509.227 2.354-2.47.236 1.474 15.304 2.47-.236.226 2.354-5.325.509m5.409-20.713 5.784-.553c1.304-.124 2.308-.12 3.012.014.945.182 1.78.586 2.501 1.212.722.626 1.303 1.423 1.741 2.391.438.962.728 2.174.868 3.636.124 1.285.07 2.408-.16 3.37-.284 1.173-.755 2.145-1.414 2.918-.498.585-1.199 1.071-2.104 1.458-.677.287-1.6.486-2.77.598l-5.955.569-1.504-15.613m3.42 2.339.995 10.341 2.363-.225c.884-.085 1.517-.195 1.9-.332.5-.177.904-.434 1.21-.771.313-.338.542-.865.69-1.582.145-.723.16-1.688.044-2.895s-.312-2.123-.588-2.75c-.276-.625-.624-1.1-1.044-1.426-.42-.325-.932-.523-1.536-.595-.451-.057-1.322-.024-2.612.1l-1.422.135M61.39 30.95l-5.245-15.256 3.24-.31 3.395 10.499 1.833-10.998 3.764-.36 3.797 10.644 1.356-11.136 3.187-.304-2.304 15.976-3.357.321-4.246-11.374-1.988 11.97-3.432.327m21.154-17.777 1.927 20.012-5.325.509-.226-2.354 2.47-.236-1.476-15.325-2.47.236-.224-2.333 5.324-.508m7.314-.699 1.927 20.012-5.325.509-.227-2.354 2.47-.236-1.475-15.325-2.47.236-.225-2.333 5.325-.508" fill="#6184a3"/>
+  <g fill-rule="evenodd">
+    <path d="M174.76 201.6c-6.046 2.467-10.168 4.42-12.885 6.35s-3.193 4.6-3.246 6.267c-.027.832.08 1.777.632 2.44.55.662 1.807 1.874 2.757 2.385 1.901 1.023 7.542 2.43 10.52 3.073 11.908 2.577 26.805 1.682 26.805 1.682 1.694 1.245 2.833 2.824 3.27 4.269 4.576-1.887 11.81-6.585 13.156-8.578-5.45-4.2-10.797-6.333-16.513-8.308-1.598-.72-2.88-1.227-.717 2.556.985 2.473.858 5.052.572 7.419 0 0-16.527.406-28.238-2.127-2.928-.633-5.467-.955-7.22-1.898-.876-.472-1.482-.821-1.915-1.341s-.22-1.291-.201-1.86c.036-1.135.253-1.67 2.861-3.524s5.655-3.362 11.66-5.812c-.088-1.291-.29-2.506-1.298-2.993z" fill="url(#e)" transform="matrix(.99993 0 0 .99598 -158.095 -157.774)"/>
+    <path d="M269.63 220.75c-1.436-.14-2.58.303-2.56 1.502.943.857 1.349 2.435 1.485 3.14s.036 1.22-.486 1.89c-1.043 1.342-3.125 1.57-6.5 2.72-6.752 2.305-16.893 2.526-27.907 3.847-22.028 2.642-39.032 3.761-39.032 3.761 1.983-4.647 6.328-4.412 6.349-8.21.273-.897-3.146-1.316-5.1-.107-4.267 3.702-7.591 6.754-10.694 10.513l1.888 3.085s26.13-2.89 48.198-5.536c11.034-1.324 20.956-1.999 27.81-4.338 3.427-1.169 5.96-1.49 7.641-3.52.632-.762 1.352-3.046 1.068-4.733-.22-1.302-1.15-3.098-2.16-4.014z" fill="url(#f)" transform="matrix(.99993 0 0 .99598 -158.095 -157.774)"/>
+    <path d="M254.36 220.34c-6.85 3.242-7.153 8.61-5.96 12.799s5.263 8.757 9.322 12.406c8.116 7.299 12.06 9.332 12.06 9.332-3.715-.104-7.9-1.412-8.133.493-.949 2.975 11.49 3.475 17.438 2.702-1.395-7.579-3.794-13.215-7.732-14.903-1.685-.148.312 4.724.77 9.396 0 0-3.625-1.732-11.605-8.908-3.99-3.588-7.374-7.342-8.473-11.201s.077-6.12 4.95-9.532c.929-.995-1.29-2.459-2.637-2.584z" fill="url(#g)" transform="matrix(.99993 0 0 .99598 -158.095 -157.774)"/>
+  </g>
+  <path d="m213.97 234.58 2.188-14.429 15.22 6.088 21.494 29.948-20.406 9.218-18.495-30.826z" fill="url(#h)" transform="matrix(.99993 0 0 .99598 -158.095 -157.774)"/>
+  <path d="m232.56 219.53-15.928.322 3.088-15.157 12.84 14.835z" fill="url(#i)" fill-rule="evenodd" stroke="#000" stroke-linejoin="round" transform="matrix(.99993 0 0 .99598 -158.095 -157.774)"/>
+  <path d="m63.49 60.634-4.412.078.854-3.966 3.557 3.888z" fill="#812310" fill-rule="evenodd"/>
+  <path d="m269.44 159.27.098 8.915 8.058 8.723 7.76.8-52.808 41.84-6.665-3.307-5.083-5.618-1.09-5.912 49.73-45.44z" fill="url(#j)" fill-rule="evenodd" stroke="#000" stroke-linejoin="round" transform="matrix(.99993 0 0 .99598 -158.095 -157.774)"/>
+  <path d="m268.95 168.33 8.343 8.827-51.101 38.683-4.92-5.443 47.678-42.066z" fill="url(#k)" fill-rule="evenodd" transform="matrix(.99993 0 0 .99598 -158.095 -157.774)"/>
+  <path d="m285.34 177.73-8.162-.866-7.752-8.679.013-9.143 8.362.752 7.189 9.577.35 8.359z" fill="#ffe965" fill-rule="evenodd" stroke="#000" stroke-linejoin="round" transform="matrix(.99993 0 0 .99598 -158.095 -157.774)"/>
+  <path d="m122.605 10.009.165 4.04-3.814-.714-2.874-3.176-.281-3.52 3.854-.166 2.95 3.536z" fill="#cb391c" fill-rule="evenodd"/>
+  <path d="m183.89 256.83 1-16.307 17.288 8.44 26.055 38.01-29.281-1.135-15.062-29.009z" fill="url(#l)" transform="matrix(.99993 0 0 .99598 -158.095 -157.774)"/>
+  <path d="m200.91 238.45-8.046 15.774-7.056-13.573 15.102-2.2z" fill="url(#m)" stroke="#000" stroke-linejoin="round" transform="matrix(.99993 0 0 .99598 -158.095 -157.774)"/>
+  <path d="m201.05 238.55 62.117 24.919-7.887 3.214-4.351 9.31 1.171 9.964-59.315-31.728-.494-7.364 3.096-5.828 5.662-2.488z" fill="url(#n)" stroke="#000" stroke-linejoin="round" transform="matrix(.99993 0 0 .99598 -158.095 -157.774)"/>
+  <path d="m255.28 266.54 7.924-3.048.853 10.24-3.9 8.29-8.047 3.78-1.34-9.631 4.51-9.631z" fill="url(#o)" stroke="#000" stroke-linejoin="round" transform="matrix(.99993 0 0 .99598 -158.095 -157.774)"/>
+  <path d="m195.75 241.42 59.131 24.796-4.592 9.766-57.49-29.01 2.951-5.553z" fill="url(#p)" transform="matrix(.99993 0 0 .99598 -158.095 -157.774)"/>
+  <path d="m96.907 116.33 2.084-4.09 2.964-1.067.695 3.359-1.768 3.841-3.155 1.378-.82-3.422z" fill="#00b527"/>
+  <path d="m28.462 82.257 3.55-.471-2.024 3.525-1.526-3.054z" fill="#258209"/>
+</svg>

--- a/lib/tpl/dokuwiki/tpl_header.php
+++ b/lib/tpl/dokuwiki/tpl_header.php
@@ -19,13 +19,18 @@ if (!defined('DOKU_INC')) die();
 
         <h1 class="logo"><?php
             // get logo either out of the template images folder or data/media folder
-            $logoSize = array();
-            $logo = tpl_getMediaFile(array(':wiki:logo.png', ':logo.png', 'images/logo.png'), false, $logoSize);
+            $logoSize = [];
+            $logo = tpl_getMediaFile([
+                ':wiki:logo.svg', ':logo.svg',
+                ':wiki:logo.png', ':logo.png',
+                'images/logo.svg', 'images/logo.png'
+            ], false, $logoSize);
 
             // display logo and wiki title in a link to the home page
             tpl_link(
                 wl(),
-                '<img src="'.$logo.'" '.$logoSize[3].' alt="" /> <span>'.$conf['title'].'</span>',
+                '<img src="' . $logo . '" ' . ($logoSize ? $logoSize[3] : '') . ' alt="" />' .
+                '<span>' . $conf['title'] . '</span>',
                 'accesskey="h" title="' . tpl_getLang('home') . ' [h]"'
             );
         ?></h1>


### PR DESCRIPTION
Inspired by https://forum.dokuwiki.org/d/20964-logo-too-big this adds SVG support for setting the logo in the dokuwiki template.

Note: This introduces a fixed height for the logo (64px), previously users could decide their logo size by simply uploading it in the right size. Users who want a larger sized logo will have to override the height in a userstyle now