### PR TITLE
Add JSON based alternative to XMLRPC

### DIFF
--- a/inc/Remote/Api.php
+++ b/inc/Remote/Api.php
@@ -277,7 +277,7 @@ class Api
             return true;
         }
 
-        return auth_isMember($conf['remoteuser'], $INPUT->server->str('REMOTE_USER'), (array) $USERINFO['grps']);
+        return auth_isMember($conf['remoteuser'], $INPUT->server->str('REMOTE_USER'), (array) ($USERINFO['grps'] ?? []));
     }
 
     /**

--- a/inc/Remote/Api.php
+++ b/inc/Remote/Api.php
@@ -277,7 +277,11 @@ class Api
             return true;
         }
 
-        return auth_isMember($conf['remoteuser'], $INPUT->server->str('REMOTE_USER'), (array) ($USERINFO['grps'] ?? []));
+        return auth_isMember(
+            $conf['remoteuser'],
+            $INPUT->server->str('REMOTE_USER'),
+            (array)($USERINFO['grps'] ?? [])
+        );
     }
 
     /**

--- a/inc/Remote/JsonRpcServer.php
+++ b/inc/Remote/JsonRpcServer.php
@@ -28,6 +28,8 @@ class JsonRpcServer
     public function serve()
     {
         global $conf;
+        global $INPUT;
+
         if (!$conf['remote']) {
             http_status(404);
             throw new RemoteException("JSON-RPC server not enabled.", -32605);
@@ -35,8 +37,15 @@ class JsonRpcServer
         if (!empty($conf['remotecors'])) {
             header('Access-Control-Allow-Origin: ' . $conf['remotecors']);
         }
-
-        global $INPUT;
+        if ($INPUT->server->str('REQUEST_METHOD') !== 'POST') {
+            http_status(405);
+            header('Allow: POST');
+            throw new RemoteException("JSON-RPC server only accepts POST requests.", -32606);
+        }
+        if ($INPUT->server->str('CONTENT_TYPE') !== 'application/json') {
+            http_status(415);
+            throw new RemoteException("JSON-RPC server only accepts application/json requests.", -32606);
+        }
 
         $call = $INPUT->server->str('PATH_INFO');
         $call = trim($call, '/');

--- a/inc/Remote/JsonRpcServer.php
+++ b/inc/Remote/JsonRpcServer.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace dokuwiki\Remote;
+
+/**
+ * Provide the Remote XMLRPC API as a JSON based API
+ */
+class JsonRpcServer
+{
+
+    protected $remote;
+
+    /**
+     * JsonRpcServer constructor.
+     */
+    public function __construct()
+    {
+        $this->remote = new Api();
+        $this->remote->setFileTransformation(array($this, 'toFile'));
+    }
+
+    /**
+     * Serve the request
+     *
+     * @return mixed
+     * @throws RemoteException
+     */
+    public function serve()
+    {
+        global $conf;
+        if (!$conf['remote']) {
+            http_status(404);
+            throw new RemoteException("JSON-RPC server not enabled.", -32605);
+        }
+        if (!empty($conf['remotecors'])) {
+            header('Access-Control-Allow-Origin: ' . $conf['remotecors']);
+        }
+
+        global $INPUT;
+
+        $call = $INPUT->server->str('PATH_INFO');
+        $call = trim($call, '/');
+        $args = json_decode(file_get_contents('php://input'), true);
+        if (!is_array($args)) $args = [];
+
+        return $this->call($call, $args);
+    }
+
+    /**
+     * Call an API method
+     *
+     * @param string $methodname
+     * @param array $args
+     * @return mixed
+     * @throws RemoteException
+     */
+    public function call($methodname, $args)
+    {
+        try {
+            $result = $this->remote->call($methodname, $args);
+            return $result;
+        } catch (AccessDeniedException $e) {
+            if (!isset($_SERVER['REMOTE_USER'])) {
+                http_status(401);
+                throw new RemoteException("server error. not authorized to call method $methodname", -32603);
+            } else {
+                http_status(403);
+                throw new RemoteException("server error. forbidden to call the method $methodname", -32604);
+            }
+        } catch (RemoteException $e) {
+            http_status(400);
+            throw $e;
+        }
+    }
+
+    /**
+     * @param string $data
+     * @return string
+     */
+    public function toFile($data)
+    {
+        return base64_encode($data);
+    }
+
+}

--- a/lib/exe/jsonrpc.php
+++ b/lib/exe/jsonrpc.php
@@ -1,0 +1,31 @@
+<?php
+
+use dokuwiki\Remote\JsonRpcServer;
+
+if (!defined('DOKU_INC')) define('DOKU_INC', __DIR__ . '/../../');
+
+require_once(DOKU_INC . 'inc/init.php');
+session_write_close();  //close session
+
+header('Content-Type: application/json');
+
+$server = new JsonRpcServer();
+try {
+    $result = [
+        'error' => [
+            'code' => 0,
+            'message' => 'success'
+        ],
+        'data' => $server->serve(),
+    ];
+} catch (\Exception $e) {
+    $result = [
+        'error' => [
+            'code' => $e->getCode(),
+            'message' => $e->getMessage()
+        ],
+        'data' => null,
+    ];
+}
+
+echo json_encode($result);


### PR DESCRIPTION
XMLRPC is a rather outdated and old-fashioned protocol not much in use anymore. Developers prefer simpler, JSON based APIs.

This adds a new "JSONRPC" API. Basically it exposes exactly the same method calls as the XMLRPC API but using JSON instead of XML. It's not a classical REST API, but should be just as easy to use for developers.

Here is an example call using CURL:

    curl http://localhost/dokuwiki/lib/exe/jsonrpc.php/wiki.getPageInfo \
       -H 'Content-Type: application/json' \
       -H "Authorization: Bearer $token" \
       -d '["wiki:syntax"]'

Please note that the above uses the token auth implemented in #2432. Authentication via basic auth or cookies would work as well.