### PR TITLE
fix XSS in RSS syntax

### DIFF
--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -1280,17 +1280,15 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
             for($x = $start; $x != $end; $x += $mod) {
                 $item = $feed->get_item($x);
                 $this->doc .= '<li><div class="li">';
-                // support feeds without links
+
                 $lnkurl = $item->get_permalink();
+                $title = html_entity_decode($item->get_title(), ENT_QUOTES, 'UTF-8');
+
+                // support feeds without links
                 if($lnkurl) {
-                    // title is escaped by SimplePie, we unescape here because it
-                    // is escaped again in externallink() FS#1705
-                    $this->externallink(
-                        $item->get_permalink(),
-                        html_entity_decode($item->get_title(), ENT_QUOTES, 'UTF-8')
-                    );
+                    $this->externallink($item->get_permalink(), $title);
                 } else {
-                    $this->doc .= ' '.$item->get_title();
+                    $this->doc .= ' '.hsc($item->get_title());
                 }
                 if($params['author']) {
                     $author = $item->get_author(0);
@@ -1304,8 +1302,11 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
                     $this->doc .= ' ('.$item->get_local_date($conf['dformat']).')';
                 }
                 if($params['details']) {
+                    $desc = $item->get_description();
+                    $desc = strip_tags($desc);
+                    $desc = html_entity_decode($desc, ENT_QUOTES, 'UTF-8');
                     $this->doc .= '<div class="detail">';
-                    $this->doc .= strip_tags($item->get_description());
+                    $this->doc .= hsc($desc);
                     $this->doc .= '</div>';
                 }
 


### PR DESCRIPTION
The title was not correctly escaped when written to the doc in xhtml renderer.

SimplePie does no content escaping on its own (a comment in the code seems to suggest that that was assumed). Instead the content is passed on as-is from the feed.

This patch also applies some more escaping on the description output (though it should have been relatively safe thanks to the use of striptags).

This was discovered by @ry0tak and reported in
https://huntr.dev/bounties/c6119106-1a5c-464c-94dd-ee7c5d0bece0/