### PR TITLE
Remove link, because it is wrongly cached. Fixes #3013

### DIFF
--- a/inc/lang/en/onceexisted.txt
+++ b/inc/lang/en/onceexisted.txt
@@ -1,3 +1,3 @@
 ======= This page does not exist anymore ======
 
-You've followed a link to a page that no longer exists. You can check the list of [[?do=revisions|old revisions]] to see when and why it was deleted, access old revisions or restore it.
+You've followed a link to a page that no longer exists. You can check the list of **Old revisions** to see when and why it was deleted, access old revisions or restore it.


### PR DESCRIPTION
Our should it be reformulated, such that it is more clear that the Old revision are an item in the page tools?