### PR TITLE
enforce content type on XML-RPC. addresses #3991

### DIFF
--- a/_test/tests/inc/XmlRpcServer.test.php
+++ b/_test/tests/inc/XmlRpcServer.test.php
@@ -64,6 +64,7 @@ EOD;
 </methodResponse>
 EOD;
 
+        $_SERVER['CONTENT_TYPE'] = 'text/xml';
         $this->server->serve($request);
         $this->assertXmlStringEqualsXmlString(trim($expected), trim($this->server->output));
     }

--- a/inc/Remote/XmlRpcServer.php
+++ b/inc/Remote/XmlRpcServer.php
@@ -37,7 +37,10 @@ class XmlRpcServer extends Server
         }
         if (
             !isset($_SERVER['CONTENT_TYPE']) ||
-            ($_SERVER['CONTENT_TYPE'] !== 'text/xml' && $_SERVER['CONTENT_TYPE'] !== 'application/xml')
+            (
+                strtolower($_SERVER['CONTENT_TYPE']) !== 'text/xml' &&
+                strtolower($_SERVER['CONTENT_TYPE']) !== 'application/xml'
+            )
         ) {
             throw new ServerException('XML-RPC server accepts XML requests only.', -32606);
         }

--- a/inc/Remote/XmlRpcServer.php
+++ b/inc/Remote/XmlRpcServer.php
@@ -25,7 +25,7 @@ class XmlRpcServer extends Server
         parent::__construct(false, false, $wait);
     }
 
-    /** @inheritdoc  */
+    /** @inheritdoc */
     public function serve($data = false)
     {
         global $conf;
@@ -34,6 +34,12 @@ class XmlRpcServer extends Server
         }
         if (!empty($conf['remotecors'])) {
             header('Access-Control-Allow-Origin: ' . $conf['remotecors']);
+        }
+        if (
+            !isset($_SERVER['CONTENT_TYPE']) ||
+            ($_SERVER['CONTENT_TYPE'] !== 'text/xml' && $_SERVER['CONTENT_TYPE'] !== 'application/xml')
+        ) {
+            throw new ServerException('XML-RPC server accepts XML requests only.', -32606);
         }
 
         parent::serve($data);


### PR DESCRIPTION
This ensures only text/xml or application/xml content types are accepted when communicating with the XML-RPC API