### PR TITLE
return false in getUserData in case of errors

### DIFF
--- a/lib/plugins/authad/auth.php
+++ b/lib/plugins/authad/auth.php
@@ -201,9 +201,9 @@ class auth_plugin_authad extends DokuWiki_Auth_Plugin
         global $ID;
         global $INPUT;
         $adldap = $this->initAdLdap($this->getUserDomain($user));
-        if (!$adldap) return array();
+        if (!$adldap) return false;
 
-        if ($user == '') return array();
+        if ($user == '') return false;
 
         $fields = array('mail', 'displayname', 'samaccountname', 'lastpwd', 'pwdlastset', 'useraccountcontrol');
 
@@ -215,7 +215,7 @@ class auth_plugin_authad extends DokuWiki_Auth_Plugin
         //get info for given user
         $result = $adldap->user()->info($this->getUserName($user), $fields);
         if ($result == false) {
-            return array();
+            return false;
         }
 
         //general user info


### PR DESCRIPTION
The interface contract for the method getUserData does not allow an empty array to be returned. It requires either `false` or an array containing at least the keys `'name'`, `'mail'` and `'grps'` to be returned.

This should fix #4004.

Note: I do not use the AuthAD plugin and I have no AD to test against. Someone able to test this against a real AD should do so before merging this PR.

Note 2: The code is somewhat weird in that in cases where `is_array($info['grps'])` is `false` statements such as `$info['grps'][] = …` are used. Maybe that works, maybe it doesn't. I have not tested this. But I'd consider this to be very bad style because it seems to rely on unspecified implementation details. This probably needs to be fixed as well.