### PR TITLE
Prevent double escaping of form labels

### DIFF
--- a/inc/Form/Form.php
+++ b/inc/Form/Form.php
@@ -336,7 +336,7 @@ class Form extends Element
      */
     public function addLabelHTML($content, $for='', $pos = -1)
     {
-        $element = new LabelElement(hsc($content));
+        $element = new LabelElement($content);
 
         if (is_a($for, '\dokuwiki\Form\Element')) {
             /** @var Element $for */


### PR DESCRIPTION
`\dokuwiki\Form\Form::addLabel()` used `hsc()` on content and then sent it to `addLabelHTML()` which does `hsc()` again