### PR TITLE
Fix undefined array key on Revision page

### DIFF
--- a/inc/ChangeLog/RevisionInfo.php
+++ b/inc/ChangeLog/RevisionInfo.php
@@ -36,7 +36,7 @@ class RevisionInfo
     {
         if (is_array($info) && isset($info['id'])) {
             // define strategy context
-            $info['mode'] = $info['media'] ? 'media' : 'page';
+            $info['mode'] = (isset($info['media']) && $info['media']) ? 'media' : 'page';
         } else {
             $info = [
                 'mode' => 'page',


### PR DESCRIPTION
When accessing a page with a Draft saved, above the revision there's a "Undefined array key" message.