### PR TITLE
Fix PHP error if user doesn't exists

### DIFF
--- a/inc/Action/Resendpwd.php
+++ b/inc/Action/Resendpwd.php
@@ -149,7 +149,7 @@ class Resendpwd extends AbstractAclAction
             }
 
             $userinfo = $auth->getUserData($user, $requireGroups = false);
-            if (!$userinfo['mail']) {
+            if (!is_array($userinfo) || !$userinfo['mail']) {
                 msg($lang['resendpwdnouser'], -1);
                 return false;
             }

--- a/inc/Action/Resendpwd.php
+++ b/inc/Action/Resendpwd.php
@@ -97,7 +97,7 @@ class Resendpwd extends AbstractAclAction
 
             $user = io_readfile($tfile);
             $userinfo = $auth->getUserData($user, $requireGroups = false);
-            if (!$userinfo['mail']) {
+            if (!is_array($userinfo) || !$userinfo['mail']) {
                 msg($lang['resendpwdnouser'], -1);
                 return false;
             }


### PR DESCRIPTION
The "mail" value on array doesn't exists if user doesn't exists on the database (e.g. using authlocal it returns "false" instead of an array object), so this fix attempts to check if it's an array first before accessing the "mail" key.