### PR TITLE
ldap: do not crash if gidnumber is not present

### DIFF
--- a/lib/plugins/authldap/auth.php
+++ b/lib/plugins/authldap/auth.php
@@ -238,7 +238,7 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin
 
         // general user info
         $info['dn'] = $user_result['dn'];
-        $info['gid'] = $user_result['gidnumber'][0];
+        $info['gid'] = $user_result['gidnumber'][0] ?? null;
         $info['mail'] = $user_result['mail'][0];
         $info['name'] = $user_result['cn'][0];
         $info['grps'] = array();


### PR DESCRIPTION
gidnumber is only present with posixGroup class. If LDAP is configured to have users with another class, this could be absent.

https://www.rfc-editor.org/rfc/rfc2307.txt