### PR TITLE
Fixes PHP 8 warning when editing drafts on PHP 8

### DIFF
--- a/inc/Action/Draft.php
+++ b/inc/Action/Draft.php
@@ -31,7 +31,7 @@ class Draft extends AbstractAction
     {
         parent::checkPreconditions();
         global $INFO;
-        if (!file_exists($INFO['draft'])) throw new ActionException('edit');
+        if (!isset($INFO['draft']) || !file_exists($INFO['draft'])) throw new ActionException('edit');
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
The following error is thrown on PHP 8.3 while attempt to edit a Draft:

Warning: Undefined array key "draft" in /home/robertinho/public_html/wiki/inc/Action/Draft.php on line 34

Warning: Cannot modify header information - headers already sent by (output started at /home/robertinho/public_html/wiki/inc/Action/Draft.php:34) in /home/robertinho/public_html/wiki/inc/actions.php on line 38