### PR TITLE
fix no error message was shown on input errors

### DIFF
--- a/lib/plugins/config/admin.php
+++ b/lib/plugins/config/admin.php
@@ -62,6 +62,7 @@ class admin_plugin_config extends DokuWiki_Admin_Plugin {
             send_redirect(wl($ID, array('do' => 'admin', 'page' => 'config'), true, '&'));
         } else {
             $this->hasErrors = true;
+            msg($this->getLang('error'), -1);
         }
     }
 


### PR DESCRIPTION
The error message was shown if the saving action throws exceptions, but not for input errors on saving. Without a message users has no clue they have to search for the red marked settings.