### PR TITLE
SubscriptionSender: Send mail to each subscriber individually

### DIFF
--- a/_test/tests/Subscriptions/BulkSubscriptionsSenderTest.php
+++ b/_test/tests/Subscriptions/BulkSubscriptionsSenderTest.php
@@ -46,7 +46,7 @@ class BulkSubscriptionsSenderTest extends DokuWikiTest
 
         // should trigger a mail
         $this->assertEquals(1, $sub->sendBulk('sub1:test'));
-        $this->assertEquals(['arthur@example.com'], array_column($mailerMock->mails, 'Bcc'));
+        $this->assertEquals(['arthur@example.com'], array_column($mailerMock->mails, 'To'));
 
         $mailerMock->mails = [];
 
@@ -57,7 +57,7 @@ class BulkSubscriptionsSenderTest extends DokuWikiTest
 
         // should not trigger a mail, because the subscription time has not been reached, yet
         $this->assertEquals(0, $sub->sendBulk('sub1:test'));
-        $this->assertEquals([], array_column($mailerMock->mails, 'Bcc'));
+        $this->assertEquals([], array_column($mailerMock->mails, 'To'));
 
         // reset the subscription time
         $manager->add('sub1:', 'testuser', 'digest', '978328800'); // last mod 2001-01-01
@@ -66,7 +66,7 @@ class BulkSubscriptionsSenderTest extends DokuWikiTest
         $this->assertEquals(3, $sub->sendBulk('sub1:test'));
         $this->assertEquals(
             ['arthur@example.com', 'arthur@example.com', 'arthur@example.com'],
-            array_column($mailerMock->mails, 'Bcc')
+            array_column($mailerMock->mails, 'To')
         );
     }
 
@@ -88,7 +88,7 @@ class BulkSubscriptionsSenderTest extends DokuWikiTest
 
         // should trigger a mail
         $this->assertEquals(1, $sub->sendBulk('sub1:test'));
-        $this->assertEquals(['arthur@example.com'], array_column($mailerMock->mails, 'Bcc'));
+        $this->assertEquals(['arthur@example.com'], array_column($mailerMock->mails, 'To'));
 
         $mailerMock->mails = [];
 
@@ -99,13 +99,13 @@ class BulkSubscriptionsSenderTest extends DokuWikiTest
 
         // should not trigger a mail, because the subscription time has not been reached, yet
         $this->assertEquals(0, $sub->sendBulk('sub1:test'));
-        $this->assertEquals([], array_column($mailerMock->mails, 'Bcc'));
+        $this->assertEquals([], array_column($mailerMock->mails, 'To'));
 
         // reset the subscription time
         $manager->add('sub1:', 'testuser', 'list', '978328800'); // last mod 2001-01-01
 
         // we now should get a single mail for all three changes
         $this->assertEquals(1, $sub->sendBulk('sub1:test'));
-        $this->assertEquals(['arthur@example.com'], array_column($mailerMock->mails, 'Bcc'));
+        $this->assertEquals(['arthur@example.com'], array_column($mailerMock->mails, 'To'));
     }
 }

--- a/_test/tests/inc/mailer.test.php
+++ b/_test/tests/inc/mailer.test.php
@@ -377,5 +377,27 @@ A test mail in <strong>html</strong>
         $this->assertEquals('Foo tar', $name);
 
     }
+
+    function test_splitAddress() {
+        $mail = new TestMailer();
+
+        $output = ['test@example.com'];
+        $addresses = $mail->splitAddress('test@example.com');
+        $this->assertEquals($output, $addresses);
+        $addresses = $mail->splitAddress($output);
+        $this->assertEquals($output, $addresses);
+
+        $output = ['test1@example.com', 'test2@example.com'];
+        $addresses = $mail->splitAddress('test1@example.com,test2@example.com');
+        $this->assertEquals($output, $addresses);
+        $addresses = $mail->splitAddress($output);
+        $this->assertEquals($output, $addresses);
+
+        $output = ['föö <foo@bar.com>', 'me@somewhere.com', '"foo, Dr." <foo@bar.com>'];
+        $addresses = $mail->splitAddress('föö <foo@bar.com>,me@somewhere.com,"foo, Dr." <foo@bar.com>');
+        $this->assertEquals($output, $addresses);
+        $addresses = $mail->splitAddress($output);
+        $this->assertEquals($output, $addresses);
+    }
 }
 //Setup VIM: ex: et ts=4 :

--- a/inc/Mailer.class.php
+++ b/inc/Mailer.class.php
@@ -338,6 +338,26 @@ class Mailer {
     }
 
     /**
+     * Splits a string with multiple email addresses into an array
+     *
+     * @param string|string[]  $addresses Multiple adresses separated by commas or as array
+     * @return string[]  the email addresses as array
+     */
+    public function splitAddress($addresses) {
+        if(!is_array($addresses)){
+            $count = preg_match_all('/\s*(?:("[^"]*"[^,]+),*)|([^,]+)\s*,*/', $addresses, $matches, PREG_SET_ORDER);
+            $addresses = array();
+            if ($count !== false && is_array($matches)) {
+                foreach ($matches as $match) {
+                    array_push($addresses, rtrim($match[0], ','));
+                }
+            }
+        }
+
+        return $addresses;
+    }
+
+    /**
      * Sets an email address header with correct encoding
      *
      * Unicode characters will be deaccented and encoded base64
@@ -357,15 +377,8 @@ class Mailer {
      */
     public function cleanAddress($addresses) {
         $headers = '';
-        if(!is_array($addresses)){
-            $count = preg_match_all('/\s*(?:("[^"]*"[^,]+),*)|([^,]+)\s*,*/', $addresses, $matches, PREG_SET_ORDER);
-            $addresses = array();
-            if ($count !== false && is_array($matches)) {
-                foreach ($matches as $match) {
-                    array_push($addresses, rtrim($match[0], ','));
-                }
-            }
-        }
+
+        $addresses = $this->splitAddress($addresses);
 
         foreach($addresses as $part) {
             $part = preg_replace('/[\r\n\0]+/', ' ', $part); // remove attack vectors


### PR DESCRIPTION
Some recipients (especially mailing lists) do not accept mails if the recipient is not listed in the To-header. With this commit each mail will be sent individually with the email address as To instead of Bcc to preserve privacy.

Fixes #1422 