### PR TITLE
Fix listblock preformatted overlap

### DIFF
--- a/inc/Parsing/Lexer/Lexer.php
+++ b/inc/Parsing/Lexer/Lexer.php
@@ -149,6 +149,13 @@ class Lexer
             if ($currentLength === $length) {
                 return false;
             }
+            // If we are closing a block and the last character consumed by our matched
+            //  string is a newline, put it back.  See the following for details:
+            //  https://github.com/dokuwiki/dokuwiki/issues/4054
+            if ($mode == "__exit" && substr($matched, -1) == "\n") {
+                $raw = "\n" . $raw;
+                $currentLength++;
+            }
             $length = $currentLength;
             $pos = $initialLength - $currentLength;
         }

--- a/inc/Parsing/ParserMode/Preformatted.php
+++ b/inc/Parsing/ParserMode/Preformatted.php
@@ -12,8 +12,8 @@ class Preformatted extends AbstractMode
         $this->Lexer->addEntryPattern('\n\t(?![\*\-])', $mode, 'preformatted');
 
         // How to effect a sub pattern with the Lexer!
-        $this->Lexer->addPattern('\n  ', 'preformatted');
-        $this->Lexer->addPattern('\n\t', 'preformatted');
+        $this->Lexer->addPattern('\n  (?![\*\-])', 'preformatted');
+        $this->Lexer->addPattern('\n\t(?![\*\-])', 'preformatted');
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
Issue:  https://github.com/dokuwiki/dokuwiki/issues/4054

This PR updates the lexer to put back a newline that is consumed by the exit of a block, as well as updating the Preformatted addPattern to match addEntryPattern, so it doesn't consume subsequent listblock lines.