### PR TITLE
Fix PHP 8 Warning in Media Manager on Non-existent Namespaces

### DIFF
--- a/inc/media.php
+++ b/inc/media.php
@@ -1697,15 +1697,17 @@ function media_nstree($ns)
         else $tmp_ns = $part;
 
         // find the namespace parts or insert them
-        while ($data[$pos]['id'] != $tmp_ns) {
-            if (
-                $pos >= count($data) ||
-                ($data[$pos]['level'] <= $level + 1 && Sort::strcmp($data[$pos]['id'], $tmp_ns) > 0)
-            ) {
-                array_splice($data, $pos, 0, [['level' => $level + 1, 'id' => $tmp_ns, 'open' => 'true']]);
-                break;
+        if (!empty($data[$pos]['id'])) {
+            while ($data[$pos]['id'] != $tmp_ns) {
+                if (
+                    $pos >= count($data) ||
+                    ($data[$pos]['level'] <= $level+1 && Sort::strcmp($data[$pos]['id'], $tmp_ns) > 0)
+                ) {
+                    array_splice($data, $pos, 0, array(array('level' => $level+1, 'id' => $tmp_ns, 'open' => 'true')));
+                    break;
+                }
+                ++$pos;
             }
-            ++$pos;
         }
     }
 

--- a/inc/media.php
+++ b/inc/media.php
@@ -1701,9 +1701,9 @@ function media_nstree($ns)
             while ($data[$pos]['id'] != $tmp_ns) {
                 if (
                     $pos >= count($data) ||
-                    ($data[$pos]['level'] <= $level+1 && Sort::strcmp($data[$pos]['id'], $tmp_ns) > 0)
+                    ($data[$pos]['level'] <= $level + 1 && Sort::strcmp($data[$pos]['id'], $tmp_ns) > 0)
                 ) {
-                    array_splice($data, $pos, 0, array(array('level' => $level+1, 'id' => $tmp_ns, 'open' => 'true')));
+                    array_splice($data, $pos, 0, [['level' => $level + 1, 'id' => $tmp_ns, 'open' => 'true']]);
                     break;
                 }
                 ++$pos;


### PR DESCRIPTION
When modifying the URL to access a non-existent namespace using Media Manager (e.g. https://wiki.example.com/doku.php?id=zabbix&do=media&ns=zabbix), the following PHP8 Warnings are being thrown:

Warning: Undefined array key 38 in /home/robertinho/public_html/wiki/inc/media.php on line 1626

Warning: Trying to access array offset on value of type null in /home/robertinho/public_html/wiki/inc/media.php on line 1626

![image](https://github.com/dokuwiki/dokuwiki/assets/2974895/63fc3827-7e11-4aef-b551-f46d1ec19b08)
