### PR TITLE
Fix updateProfile() not checking for removed $changes["pass"]

### DIFF
--- a/inc/auth.php
+++ b/inc/auth.php
@@ -1045,7 +1045,7 @@ function updateprofile()
         return false;
     }
 
-    if ($changes['pass']) {
+    if (array_key_exists('pass', $changes) && $changes['pass']) {
         // update cookie and session with the changed data
         [/* user */, $sticky, /* pass */] = auth_getCookie();
         $pass = auth_encrypt($changes['pass'], auth_cookiesalt(!$sticky, true));


### PR DESCRIPTION
If the authentication plugin does not support modifying passwords, we unset($changes['pass']) further above, but then the check for $changes['pass'] must also handle the case that we did indeed unset it.