### PR TITLE
Fix Undefined array key "file" and "line"

### DIFF
--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -522,9 +522,16 @@ function dbg_backtrace()
     $calls = [];
     $depth = count($backtrace) - 1;
     foreach ($backtrace as $i => $call) {
-        $location = isset($call['file']) ? $call['file'] . ':' . ($call['line'] ?? '0') : '[internal function]';
-        $function = (isset($call['class'])) ?
-            $call['class'] . $call['type'] . $call['function'] : $call['function'];
+        if (isset($call['file'])) {
+            $location = $call['file'] . ':' . ($call['line'] ?? '0');
+        } else {
+            $location = '[anonymous]';
+        }
+        if (isset($call['class'])) {
+            $function = $call['class'] . $call['type'] . $call['function'];
+        } else {
+            $function = $call['function'];
+        }
 
         $params = [];
         if (isset($call['args'])) {

--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -522,7 +522,7 @@ function dbg_backtrace()
     $calls = [];
     $depth = count($backtrace) - 1;
     foreach ($backtrace as $i => $call) {
-        $location = $call['file'] . ':' . $call['line'];
+        $location = isset($call['file']) ? $call['file'] . ':' . ($call['line'] ?? '0') : '[internal function]';
         $function = (isset($call['class'])) ?
             $call['class'] . $call['type'] . $call['function'] : $call['function'];
 


### PR DESCRIPTION
E_WARNING: Undefined array key "line"
/home/gerrit/Sites/dokuwiki/dokuwiki/inc/infoutils.php(525)

In the exception::trace this line is labeled as internal function. Of course it is an assumption that all cases without file are internal functions. Alternative is to put there for example `[unknown]`.

I did a dbg_backtrace call in the deprecated ptln(), which appeared to be a callback in template.php (that usage is already updated btw).

logviewer had:
```
2023-09-21 11:39:49
E_WARNING: Undefined array key "line"
/home/gerrit/Sites/dokuwiki/dokuwiki/inc/infoutils.php(525)
#0 /home/gerrit/Sites/dokuwiki/dokuwiki/inc/infoutils.php(525): dokuwiki\ErrorHandler::errorHandler()
#1 /home/gerrit/Sites/dokuwiki/dokuwiki/inc/deprecated.php(740): dbg_backtrace()
#2 [internal function]: ptln()
#3 /home/gerrit/Sites/dokuwiki/dokuwiki/inc/Extension/Event.php(134): call_user_func_array()
#4 /home/gerrit/Sites/dokuwiki/dokuwiki/inc/Extension/Event.php(200): dokuwiki\Extension\Event->trigger()
#5 /home/gerrit/Sites/dokuwiki/dokuwiki/inc/template.php(104): dokuwiki\Extension\Event::createAndTrigger()
#6 /home/gerrit/Sites/dokuwiki/dokuwiki/lib/tpl/dokuwiki/main.php(60): tpl_content()
#7 /home/gerrit/Sites/dokuwiki/dokuwiki/inc/actions.php(30): include('...')
#8 /home/gerrit/Sites/dokuwiki/dokuwiki/doku.php(131): act_dispatch()
#9 {main}
2023-09-21 11:40:09
E_WARNING: Undefined array key "file"
/home/gerrit/Sites/dokuwiki/dokuwiki/inc/infoutils.php(525)
#0 /home/gerrit/Sites/dokuwiki/dokuwiki/inc/infoutils.php(525): dokuwiki\ErrorHandler::errorHandler()
#1 /home/gerrit/Sites/dokuwiki/dokuwiki/inc/deprecated.php(740): dbg_backtrace()
#2 [internal function]: ptln()
#3 /home/gerrit/Sites/dokuwiki/dokuwiki/inc/Extension/Event.php(134): call_user_func_array()
#4 /home/gerrit/Sites/dokuwiki/dokuwiki/inc/Extension/Event.php(200): dokuwiki\Extension\Event->trigger()
#5 /home/gerrit/Sites/dokuwiki/dokuwiki/inc/template.php(104): dokuwiki\Extension\Event::createAndTrigger()
#6 /home/gerrit/Sites/dokuwiki/dokuwiki/lib/tpl/dokuwiki/main.php(60): tpl_content()
#7 /home/gerrit/Sites/dokuwiki/dokuwiki/inc/actions.php(30): include('...')
#8 /home/gerrit/Sites/dokuwiki/dokuwiki/doku.php(131): act_dispatch()
```