### PR TITLE
Upgrade rector to 0.18.12

### DIFF
--- a/_test/composer.json
+++ b/_test/composer.json
@@ -10,7 +10,7 @@
     },
     "prefer-stable": true,
     "require-dev": {
-        "rector/rector": "^0.18.3",
+        "rector/rector": "^0.18.12",
         "squizlabs/php_codesniffer": "^3.7",
         "phpunit/phpunit": "^8.5"
     },

--- a/_test/composer.lock
+++ b/_test/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b9c0aa944039e87220b6ec1e4e3f10a",
+    "content-hash": "76bfa04eee307c81e4853091e3406874",
     "packages": [
         {
             "name": "scotteh/php-dom-wrapper",
@@ -916,16 +916,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "0.18.7",
+            "version": "0.18.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "caba0e294a1228f64f8a9cfd0d715cc8af47c4da"
+                "reference": "ed8d5352a3faa69e4a5e315896abffd4bc29c828"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/caba0e294a1228f64f8a9cfd0d715cc8af47c4da",
-                "reference": "caba0e294a1228f64f8a9cfd0d715cc8af47c4da",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/ed8d5352a3faa69e4a5e315896abffd4bc29c828",
+                "reference": "ed8d5352a3faa69e4a5e315896abffd4bc29c828",
                 "shasum": ""
             },
             "require": {
@@ -960,7 +960,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/0.18.7"
+                "source": "https://github.com/rectorphp/rector/tree/0.18.12"
             },
             "funding": [
                 {
@@ -968,7 +968,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-13T10:11:05+00:00"
+            "time": "2023-12-04T08:47:30+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/_test/rector.php
+++ b/_test/rector.php
@@ -15,7 +15,6 @@ use Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector;
 use Rector\CodeQuality\Rector\If_\SimplifyIfReturnBoolRector;
 use Rector\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector;
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
-use Rector\CodingStyle\Rector\Class_\AddArrayDefaultToArrayPropertyRector;
 use Rector\CodingStyle\Rector\Closure\StaticClosureRector;
 use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
 use Rector\CodingStyle\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector;
@@ -30,7 +29,6 @@ use Rector\DeadCode\Rector\If_\RemoveUnusedNonEmptyArrayBeforeForeachRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
 use Rector\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector;
 use Rector\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector;
-use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Php80\Rector\Identical\StrEndsWithRector;
 use Rector\Php80\Rector\Identical\StrStartsWithRector;
@@ -117,12 +115,10 @@ return static function (RectorConfig $rectorConfig): void {
         PostIncDecToPreIncDecRector::class,
         RemoveUselessParamTagRector::class,
         DisallowedEmptyRuleFixerRector::class,
-        CountOnNullRector::class, // adds unwanted is_countable checks?
         RemoveParentCallWithoutParentRector::class,
         WrapEncapsedVariableInCurlyBracesRector::class,
         SimplifyIfReturnBoolRector::class,
         StrictArraySearchRector::class, // we cannot assume strict search is always wanted
-        AddArrayDefaultToArrayPropertyRector::class, // may break code differentiating between null and empty array
         RemoveUselessVarTagRector::class,
         TypedPropertyFromAssignsRector::class, // maybe?
         JoinStringConcatRector::class, // this does not count variables, so it creates overlong lines


### PR DESCRIPTION
Two classes in DokuWiki's skip rules were removed from rector in 0.18.12, so:
1. remove the rules in rector.php
2. update rector package to current version