### PR TITLE
automatically prune old logs

### DIFF
--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -112,6 +112,7 @@ $conf['mailreturnpath']    = '';         //use this email as returnpath for boun
 $conf['mailprefix']  = '';               //use this as prefix of outgoing mails
 $conf['htmlmail']    = 1;                //send HTML multipart mails
 $conf['dontlog'] = 'debug';              //logging facilities that should be disabled
+$conf['logretain'] = 3;                  //how many days of logs to keep
 
 /* Syndication Settings */
 $conf['sitemap']     = 0;                //Create a Google sitemap? How often? In days.

--- a/lib/plugins/config/lang/en/lang.php
+++ b/lib/plugins/config/lang/en/lang.php
@@ -148,6 +148,7 @@ $lang['mailreturnpath']    = 'Recipient email address for non delivery notificat
 $lang['mailprefix']  = 'Email subject prefix to use for automatic mails. Leave blank to use the wiki title';
 $lang['htmlmail']    = 'Send better looking, but larger in size HTML multipart emails. Disable for plain text only mails.';
 $lang['dontlog'] = 'Disable logging for these types of logs.';
+$lang['logretain'] = 'How many days of logs to keep.';
 
 /* Syndication Settings */
 $lang['sitemap']           = 'Generate Google sitemap this often (in days). 0 to disable';

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -216,6 +216,7 @@ $meta['mailreturnpath'] = ['email', '_placeholders' => true];
 $meta['mailprefix'] = ['string'];
 $meta['htmlmail'] = ['onoff'];
 $meta['dontlog'] = ['disableactions', '_choices' => ['error', 'debug', 'deprecated']];
+$meta['logretain'] = ['numeric', '_min' => 0, '_pattern' => '/^\d+$/'];
 
 $meta['_syndication'] = ['fieldset'];
 $meta['sitemap'] = ['numeric'];

--- a/lib/plugins/logviewer/action.php
+++ b/lib/plugins/logviewer/action.php
@@ -1,0 +1,52 @@
+<?php
+
+use dokuwiki\Extension\ActionPlugin;
+use dokuwiki\Extension\EventHandler;
+use dokuwiki\Extension\Event;
+
+/**
+ * DokuWiki Plugin logviewer (Action Component)
+ *
+ * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
+ * @author Andreas Gohr <andi@splitbrain.org>
+ */
+class action_plugin_logviewer extends ActionPlugin
+{
+    /** @inheritDoc */
+    public function register(EventHandler $controller)
+    {
+        $controller->register_hook('INDEXER_TASKS_RUN', 'AFTER', $this, 'pruneLogs');
+    }
+
+
+    /**
+     * Event handler for INDEXER_TASKS_RUN
+     *
+     * @see https://www.dokuwiki.org/devel:events:INDEXER_TASKS_RUN
+     * @param Event $event Event object
+     * @param mixed $param optional parameter passed when event was registered
+     * @return void
+     */
+    public function pruneLogs(Event $event, $param)
+    {
+        global $conf;
+
+        $prune = $conf['logdir'] . '/pruned';
+        if (@filemtime($prune) > time() - 24 * 60 * 60) {
+            return; // already pruned today
+        }
+
+        $logdirs = glob($conf['logdir'] . '/*', GLOB_ONLYDIR | GLOB_NOSORT);
+        foreach ($logdirs as $dir) {
+            $dates = glob($dir . '/*.log'); // glob returns sorted results
+            if (count($dates) > $conf['logretain']) {
+                $dates = array_slice($dates, 0, -1 * $conf['logretain']);
+                foreach ($dates as $date) {
+                    io_rmdir($date, true);
+                }
+            }
+        }
+
+        io_saveFile($prune, '');
+    }
+}

--- a/lib/plugins/logviewer/plugin.info.txt
+++ b/lib/plugins/logviewer/plugin.info.txt
@@ -1,7 +1,7 @@
 base   logviewer
 author Andreas Gohr
 email  andi@splitbrain.org
-date   2020-08-13
+date   2023-12-22
 name   logviewer plugin
 desc   View DokuWiki logs
 url    https://www.dokuwiki.org/plugin:logviewer


### PR DESCRIPTION
This adds a new configuration that allows to define how many logfiles per facility should be kept. Old files are pruned daily via the task runner.