### PR TITLE
More resilence when talking to plugin repo fixes #4135

### DIFF
--- a/lib/plugins/extension/admin.php
+++ b/lib/plugins/extension/admin.php
@@ -57,7 +57,7 @@ class admin_plugin_extension extends AdminPlugin
         if (!$repository->hasAccess(!$INPUT->bool('purge'))) {
             $url = $this->gui->tabURL('', ['purge' => 1], '&');
             msg($this->getLang('repo_error') .
-                ' [<a href="' . $url . '">' . $this->getLang('repo_retry') . '</a>]', -1);
+                ' [<a href="' . $url . '" rel="noreferrer">' . $this->getLang('repo_retry') . '</a>]', -1);
         }
 
         if (!in_array('ssl', stream_get_transports())) {

--- a/lib/plugins/extension/lang/en/lang.php
+++ b/lib/plugins/extension/lang/en/lang.php
@@ -101,6 +101,7 @@ $lang['auth']                         = 'This auth plugin is not enabled in conf
 $lang['install_url']                  = 'Install from URL:';
 $lang['install_upload']               = 'Upload Extension:';
 
+$lang['repo_badresponse']             = 'The plugin repository returned an invalid response.';
 $lang['repo_error']                   = 'The plugin repository could not be contacted. Make sure your server is allowed to contact www.dokuwiki.org and check your proxy settings.';
 $lang['nossl']                        = 'Your PHP seems to miss SSL support. Downloading will not work for many DokuWiki extensions.';
 


### PR DESCRIPTION
When the plugin repository answers but returns non-data (as can happen when the database isn't available, as we have learned yesterday), the extension manager still tried to deserialize the data.

This changes all communication from php-serialized to JSON encoded data. When JSON-decoding fails, the data is ignored and an error message is shown. Failure data like this will not be cached.