### PR TITLE
inc/fulltext Result from splice could be empty

### DIFF
--- a/inc/fulltext.php
+++ b/inc/fulltext.php
@@ -131,12 +131,18 @@ function _ft_pageSearch(&$data)
                 $stack[] = $pages_matched;
                 break;
             case 'AND': // and operation
-                [$pages1, $pages2] = array_splice($stack, -2);
-                $stack[] = ft_resultCombine([$pages1, $pages2]);
+                $pages = array_splice($stack, -2);
+                if (empty($pages)) {
+                    break;
+                }
+                $stack[] = ft_resultCombine($pages);
                 break;
             case 'OR':  // or operation
-                [$pages1, $pages2] = array_splice($stack, -2);
-                $stack[] = ft_resultUnite([$pages1, $pages2]);
+                $pages = array_splice($stack, -2);
+                if (empty($pages)) {
+                    break;
+                }
+                $stack[] = ft_resultUnite($pages);
                 break;
             case 'NOT': // not operation (unary)
                 $pages   = array_pop($stack);


### PR DESCRIPTION
The code for `AND` and `OR` assumes the call to splice will always return 2 elements, which isn't the case if no terms are found.

Example log messages:

    PHP Warning:  Undefined array key 0 in .../dokuwiki/inc/fulltext.php on line 134
    PHP Warning:  Undefined array key 1 in .../dokuwiki/inc/fulltext.php on line 134
    PHP Warning:  foreach() argument must be of type array|object, null given in .../dokuwiki/inc/fulltext.php on line 614

Simplified example, via `php -a`:

    php > $arr = [];
    php > [$a, $b] = array_splice($arr, -2);
    PHP Warning:  Undefined array key 0 in php shell code on line 1
    PHP Warning:  Undefined array key 1 in php shell code on line 1

To clear the warning we check if the result is empty and break early, otherwise we pass the result into `ft_resultCombine` or `ft_resultUnite`, which both handle the length 1 arrays.