### PR TITLE
Fix false errors when calling getInfo() from some plugins

### DIFF
--- a/inc/Extension/PluginTrait.php
+++ b/inc/Extension/PluginTrait.php
@@ -27,6 +27,9 @@ trait PluginTrait
             throw new \RuntimeException('Class does not follow the plugin naming convention');
         }
 
+        // class like action_plugin_myplugin_ajax belongs to plugin 'myplugin'
+        $ext = strtok($ext, '_');
+
         $base = [
             'base' => $ext,
             'author' => 'Unknown',


### PR DESCRIPTION
Assuming I have a plugin called `myplugin`, which has a class `action_plugin_myplugin_ajax` and I call `$this->getInfo()`.

What happens now is the method tries to find a `plugin.info.txt` for plugin `myplugin_ajax` and of course fails, logging an error.

This is fixed by correctly handling such common composites in class names by getting the plugin name from the relevant part before an underscore.