### PR TITLE
fix overeager optimization in Table handler. fixes #4186

### DIFF
--- a/inc/Parsing/Handler/Table.php
+++ b/inc/Parsing/Handler/Table.php
@@ -167,15 +167,12 @@ class Table extends AbstractRewriter
             $this->inTableHead = false;
             $this->countTableHeadRows = 0;
         }
-        // Look for the colspan elements and increment the colspan on the
-        // previous non-empty opening cell. Once done, delete all the cells
-        // that contain colspans
-        $counter = count($this->tableCalls);
 
         // Look for the colspan elements and increment the colspan on the
         // previous non-empty opening cell. Once done, delete all the cells
         // that contain colspans
-        for ($key = 0; $key < $counter; ++$key) {
+        $key = -1;
+        while (++$key < count($this->tableCalls)) {
             $call = $this->tableCalls[$key];
 
             switch ($call[0]) {


### PR DESCRIPTION
This reverts an optimization introduced in
bcaec9f47d06126b3e653fea89a86d8b6a6cbef8

The number of elements in $this->tableCalls may change during the loop, so they need to be recounted on every step. To protect it from being "optimized" again, the loop was changed into a while loop.

Ultimately it should be checked if this method could be optimized in another way.