### PR TITLE
use correct FeedOptions methods. fixes #4203

### DIFF
--- a/feed.php
+++ b/feed.php
@@ -52,7 +52,7 @@ $depends['purge'] = $INPUT->bool('purge');
 // time or the update interval has not passed, also handles conditional requests
 header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
 header('Pragma: public');
-header('Content-Type: ' . $options->get('mime_type'));
+header('Content-Type: ' . $options->getMimeType());
 header('X-Robots-Tag: noindex');
 if ($cache->useCache($depends)) {
     http_conditionalRequest($cache->getTime());

--- a/inc/Feed/FeedCreator.php
+++ b/inc/Feed/FeedCreator.php
@@ -63,7 +63,7 @@ class FeedCreator
         }
         $event->advise_after();
 
-        return $this->feed->createFeed($this->options->get('type'));
+        return $this->feed->createFeed($this->options->getType());
     }
 
     /**

--- a/inc/Feed/FeedCreatorOptions.php
+++ b/inc/Feed/FeedCreatorOptions.php
@@ -15,6 +15,10 @@ class FeedCreatorOptions
             'name' => 'RSS0.91',
             'mime' => 'text/xml; charset=utf-8',
         ],
+        'rss1' => [
+            'name' => 'RSS1.0',
+            'mime' => 'text/xml; charset=utf-8',
+        ],
         'rss2' => [
             'name' => 'RSS2.0',
             'mime' => 'text/xml; charset=utf-8',


### PR DESCRIPTION
This makes feed.php use the correct methods for setting the feed type and content-type header. It also adds the missing type definition for RSS 1.0