### PR TITLE
API: ignore charset when checking content types

### DIFF
--- a/inc/Remote/JsonRpcServer.php
+++ b/inc/Remote/JsonRpcServer.php
@@ -44,7 +44,9 @@ class JsonRpcServer
             header('Allow: POST');
             throw new RemoteException("JSON-RPC server only accepts POST requests.", -32606);
         }
-        if ($INPUT->server->str('CONTENT_TYPE') !== 'application/json') {
+        [$contentType] = explode(';', $INPUT->server->str('CONTENT_TYPE'), 2); // ignore charset
+        $contentType = strtolower($contentType); // mime types are case-insensitive
+        if ($contentType !== 'application/json') {
             http_status(415);
             throw new RemoteException("JSON-RPC server only accepts application/json requests.", -32606);
         }

--- a/inc/Remote/XmlRpcServer.php
+++ b/inc/Remote/XmlRpcServer.php
@@ -28,19 +28,16 @@ class XmlRpcServer extends Server
     public function serve($data = false)
     {
         global $conf;
+        global $INPUT;
         if (!$conf['remote']) {
             throw new ServerException("XML-RPC server not enabled.", -32605);
         }
         if (!empty($conf['remotecors'])) {
             header('Access-Control-Allow-Origin: ' . $conf['remotecors']);
         }
-        if (
-            !isset($_SERVER['CONTENT_TYPE']) ||
-            (
-                strtolower($_SERVER['CONTENT_TYPE']) !== 'text/xml' &&
-                strtolower($_SERVER['CONTENT_TYPE']) !== 'application/xml'
-            )
-        ) {
+        [$contentType] = explode(';', $INPUT->server->str('CONTENT_TYPE'), 2); // ignore charset
+        $contentType = strtolower($contentType); // mime types are case-insensitive
+        if ($contentType !== 'text/xml' && $contentType !== 'application/xml') {
             throw new ServerException('XML-RPC server accepts XML requests only.', -32606);
         }
 


### PR DESCRIPTION
We still expect all communication to be in UTF-8, but we really don't need a charset attribute for that.

fixes #4218, replaces #4219