### PR TITLE
Fix #4235

### DIFF
--- a/inc/Ui/Recent.php
+++ b/inc/Ui/Recent.php
@@ -162,7 +162,7 @@ class Recent extends Ui
         }
         if (!$changelog->isCurrentRevision($info['date'])) {
             $currentRevInfo = $changelog->getCurrentRevisionInfo();
-            if ($currentRevInfo['type'] == DOKU_CHANGE_TYPE_DELETE) {
+            if (($currentRevInfo['type'] ?? null) == DOKU_CHANGE_TYPE_DELETE) {
                 // the page or media file was externally deleted, updated info because the link is already red
                 // externally created and edited not updated because sorting by date is not worth so much changes
                 $info = array_merge($info, $currentRevInfo);


### PR DESCRIPTION
Fix #4235

Note: This class of problem, i.e. mismatch between documented return values vs. use of them in consumers, is somewhat prevalent and very hard to find unless they happen to trigger a warning or error.

Fixing them as they come up is ok I guess but some sort of automated method to detect these would be great.