### PR TITLE
JSINFO moved to <meta>

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -375,7 +375,7 @@ function tpl_metaheaders($alt = true)
 
     jsinfo();
     $JSINFO['sig'] = toolbar_signature();
-    $head['meta'][] = ['itemprop' => 'JSINFO', 'content' => base64_encode(json_encode($JSINFO, JSON_THROW_ON_ERROR))];
+    $head['meta'][] = ['name' => 'JSINFO', 'content' => htmlspecialchars(json_encode($JSINFO, JSON_THROW_ON_ERROR))];
 
     // load jquery
     $jquery = getCdnUrls();

--- a/inc/template.php
+++ b/inc/template.php
@@ -374,6 +374,7 @@ function tpl_metaheaders($alt = true)
     ];
 
     jsinfo();
+    $JSINFO['sig'] = toolbar_signature();
     $head['meta'][] = ['itemprop' => 'JSINFO', 'content' => base64_encode(json_encode($JSINFO, JSON_THROW_ON_ERROR))];
 
     // load jquery

--- a/inc/template.php
+++ b/inc/template.php
@@ -373,13 +373,8 @@ function tpl_metaheaders($alt = true)
         'href' => DOKU_BASE . 'lib/exe/css.php?t=' . rawurlencode($conf['template']) . '&tseed=' . $tseed
     ];
 
-    $script = "var NS='" . (isset($INFO) ? $INFO['namespace'] : '') . "';";
-    if ($conf['useacl'] && $INPUT->server->str('REMOTE_USER')) {
-        $script .= "var SIG=" . toolbar_signature() . ";";
-    }
     jsinfo();
-    $script .= 'var JSINFO = ' . json_encode($JSINFO, JSON_THROW_ON_ERROR) . ';';
-    $head['script'][] = ['_data' => $script];
+    $head['meta'][] = ['itemprop' => 'JSINFO', 'content' => base64_encode(json_encode($JSINFO, JSON_THROW_ON_ERROR))];
 
     // load jquery
     $jquery = getCdnUrls();

--- a/inc/toolbar.php
+++ b/inc/toolbar.php
@@ -276,7 +276,7 @@ function toolbar_signature()
     }
     $sig = str_replace('@DATE@', dformat(), $sig);
     $sig = str_replace('\\\\n', '\\n', $sig);
-    return json_encode($sig, JSON_THROW_ON_ERROR);
+    return $sig;
 }
 
 //Setup VIM: ex: et ts=4 :

--- a/lib/exe/js.php
+++ b/lib/exe/js.php
@@ -99,7 +99,7 @@ function js_out()
     ob_start();
 
     // add some global variables
-    echo "const JSINFO = JSON.parse(atob(document.head.querySelector('meta[itemprop=JSINFO]').content));";
+    echo "const JSINFO = JSON.parse($('<div/>').html(document.head.querySelector('meta[name=JSINFO]').content).text());";
     // TODO Is this neccessary?
     echo "const NS = JSINFO.namespace;";
     echo "const SIG = JSINFO.sig;";

--- a/lib/exe/js.php
+++ b/lib/exe/js.php
@@ -99,6 +99,13 @@ function js_out()
     ob_start();
 
     // add some global variables
+    echo "const JSINFO = JSON.parse(atob(document.head.querySelector('meta[itemprop=JSINFO]').content));";
+    // TODO Is this neccessary?
+    echo "const NS = JSINFO.namespace;";
+    // TODO From template.php. Is this neccessary?
+    if ($conf['useacl'] && $INPUT->server->str('REMOTE_USER')) {
+        echo  "var SIG=" . toolbar_signature() . ";";
+    }
     echo "var DOKU_BASE   = '" . DOKU_BASE . "';";
     echo "var DOKU_TPL    = '" . tpl_basedir($tpl) . "';";
     echo "var DOKU_COOKIE_PARAM = " . json_encode([

--- a/lib/exe/js.php
+++ b/lib/exe/js.php
@@ -102,10 +102,7 @@ function js_out()
     echo "const JSINFO = JSON.parse(atob(document.head.querySelector('meta[itemprop=JSINFO]').content));";
     // TODO Is this neccessary?
     echo "const NS = JSINFO.namespace;";
-    // TODO From template.php. Is this neccessary?
-    if ($conf['useacl'] && $INPUT->server->str('REMOTE_USER')) {
-        echo  "var SIG=" . toolbar_signature() . ";";
-    }
+    echo "const SIG = JSINFO.sig;";
     echo "var DOKU_BASE   = '" . DOKU_BASE . "';";
     echo "var DOKU_TPL    = '" . tpl_basedir($tpl) . "';";
     echo "var DOKU_COOKIE_PARAM = " . json_encode([


### PR DESCRIPTION
JSINFO moved to a HTML `<meta>` tag, to allow a strict CSP.

Contributes to the discussion at #3788.

CAN work if there are no inline JavaScripts that instantly would need the JSINFO variable.

I have to admit already the DokuWiki default template has inline JavaScript; but does not use the JSINFO variable.

Let's put it this way: When you used an inline script in the past (that gets executed instantly), you could not rely on neither `lib/exe/jquery.php` nor `lib/exe/js.php` (because these are external and deferred). Now the `JSINFO` variable gets added to that list, too.

