### PR TITLE
fix listing of plugin components

### DIFF
--- a/bin/plugin.php
+++ b/bin/plugin.php
@@ -1,11 +1,11 @@
 #!/usr/bin/env php
 <?php
 
+use dokuwiki\Extension\CLIPlugin;
 use dokuwiki\Extension\PluginController;
 use splitbrain\phpcli\CLI;
 use splitbrain\phpcli\Colors;
 use splitbrain\phpcli\Options;
-use dokuwiki\Extension\CLIPlugin;
 use splitbrain\phpcli\TableFormatter;
 
 if (!defined('DOKU_INC')) define('DOKU_INC', realpath(__DIR__ . '/../') . '/');
@@ -94,7 +94,8 @@ class PluginCLI extends CLI
      */
     protected function loadPlugin($name)
     {
-        if (plugin_isdisabled($name)) return null;
+        [$basename] = explode('_', $name); // might be a sub component
+        if (plugin_isdisabled($basename)) return null;
 
         // execute the plugin CLI
         $class = "cli_plugin_$name";

--- a/inc/Extension/PluginController.php
+++ b/inc/Extension/PluginController.php
@@ -345,7 +345,6 @@ class PluginController
         foreach ($master_list as $plugin) {
             if (file_exists(DOKU_PLUGIN . "$plugin/$type.php")) {
                 $plugins[] = $plugin;
-                continue;
             }
 
             $typedir = DOKU_PLUGIN . "$plugin/$type/";


### PR DESCRIPTION
Plugins may have one main component of a type or they might have multiple of the same type in a subdirectory.

Sometimes they may have both. This is often the case for organically grown plugin, commonly with helper classes where a helper.php exists first only to be extended by helper/*.php files later.

This patch fixes the listing of plugin(components) by type in the plugin controller.

It also adjusts bin/plugin.php to handle plugin CLI components.