### PR TITLE
Update deletedFiles.yml with improved workflow

### DIFF
--- a/.github/workflows/deletedFiles.yml
+++ b/.github/workflows/deletedFiles.yml
@@ -3,6 +3,7 @@
 # It compares the current master with the stable branch and adds all deleted files to the data/deleted.files file
 # unless they are already listed there or are excluded from the release archives (export-ignore in .gitattributes).
 # Any additions are made to the top of the list with a single trailing line before the first "# removed in" line.
+# Finally, the list of newly removed entries receives a header "# removed in $(date -I)" with the current ISO date.
 
 name: "Update deleted files"
 on:
@@ -38,10 +39,14 @@ jobs:
             if grep -q "^$F$" data/deleted.files; then
               continue
             fi
+            if ( ! test -f "data/deleted.files.tmp"); then
+              awk -v "input=# newly removed" '/# removed in/ && !found {print input; found=1} 1' data/deleted.files > data/deleted.files.tmp && cp data/deleted.files{.tmp,}
+            fi
             awk -v "input=$F" '/# removed in/ && !found {print input; found=1} 1' data/deleted.files > data/deleted.files.tmp && cp data/deleted.files{.tmp,}
           done
           if (test -f "data/deleted.files.tmp"); then
             awk '/# removed in/ && !found {printf("\n"); found=1} 1' data/deleted.files > data/deleted.files.tmp && mv data/deleted.files{.tmp,}
+            sed -i "s/^# newly removed/# removed in $(date -I)/" data/deleted.files
           fi
           
       - name: Create Pull Request

--- a/.github/workflows/deletedFiles.yml
+++ b/.github/workflows/deletedFiles.yml
@@ -1,6 +1,8 @@
 # This workflow updates the list of deleted files based on the recent changes and creates a pull request.
+# It compares the current master with the data/deleted.files file and cleans the file from any re-introduced files.
 # It compares the current master with the stable branch and adds all deleted files to the data/deleted.files file
 # unless they are already listed there or are excluded from the release archives (export-ignore in .gitattributes).
+# Any additions are made to the top of the list with a single trailing line before the first "# removed in" line.
 
 name: "Update deleted files"
 on:
@@ -18,18 +20,30 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Update deleted files
+      - name: Cleaning list from re-introduced files
+        run: |
+          for E in $(git ls-tree -r master --name-only); do
+            if (git check-attr export-ignore "$E" | grep -q "export-ignore: set"); then
+              continue
+            fi
+            grep -v "^$E$" data/deleted.files > data/deleted.files.tmp && mv data/deleted.files{.tmp,}
+          done
+          
+      - name: Update list with deleted files
         run: |
           for F in $(git diff origin/stable..HEAD --summary | awk '/^ delete/ && $4 !~ /^(VERSION)/ {print $4}'); do
             if (git check-attr export-ignore "$F" | grep -q "export-ignore: set"); then
               continue
             fi
-            if grep -q "^$F" data/deleted.files; then
+            if grep -q "^$F$" data/deleted.files; then
               continue
             fi
-            echo "$F" >> data/deleted.files
+            awk -v "input=$F" '/# removed in/ && !found {print input; found=1} 1' data/deleted.files > data/deleted.files.tmp && cp data/deleted.files{.tmp,}
           done
-
+          if (test -f "data/deleted.files.tmp"); then
+            awk '/# removed in/ && !found {printf("\n"); found=1} 1' data/deleted.files > data/deleted.files.tmp && mv data/deleted.files{.tmp,}
+          fi
+          
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:


### PR DESCRIPTION
A) Improve deleted.files Workflow with new action for cleaning list from re-introduced files

B) Improve deleted.files Workflow by adding any newest entries to the top of the list:

  * Add new entries on top of the original list and before the first "# removed in" commentary line
  * Add single trailing empty line to the end of the new list but before the original first "# removed in" line
  * Add a heading line with the current ISO date.

ref https://github.com/dokuwiki/dokuwiki/issues/4217

The major improvements are:
- cleans this file from any re-introduced file by new action "name: Cleaning list from re-introduced files"
- adds deleted files to the top of the list by use of the _awk_ processor
- takes extra care of full path names (i.e. `"^$E$"` and `"^$F$"`) to avoid cluttering _grep_ with e.g., .txt and .txt_bak files
- uses `data/deleted.files.tmp` as lock file to produce a single trailing line only after adding any deleted files (thus the "cp" in the first "awk") and removes it (the "mv" in second "awk")
- produces a header "# removed in 2024-MM-DD" with the current ISO date by use of the _sed_ stream editor