### PR TITLE
Output more version data on the admin screen

### DIFF
--- a/inc/Ui/Admin.php
+++ b/inc/Ui/Admin.php
@@ -71,6 +71,8 @@ class Admin extends Ui
     {
         echo '<div id="admin__version">';
         echo getVersion();
+        echo '<br>';
+        echo join('<br>', array_values(getRuntimeVersions()));
         echo '</div>';
     }
 

--- a/inc/Ui/Admin.php
+++ b/inc/Ui/Admin.php
@@ -72,7 +72,7 @@ class Admin extends Ui
         echo '<div id="admin__version">';
         echo getVersion();
         echo '<br>';
-        echo join('<br>', array_values(getRuntimeVersions()));
+        echo join('<br>', array_map('hsc', array_values(getRuntimeVersions())));
         echo '</div>';
     }
 

--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -7,12 +7,12 @@
  * @author     Andreas Gohr <andi@splitbrain.org>
  */
 
+use dokuwiki\Debug\DebugHelper;
 use dokuwiki\Extension\AuthPlugin;
 use dokuwiki\Extension\Event;
-use dokuwiki\Utf8\PhpString;
-use dokuwiki\Debug\DebugHelper;
 use dokuwiki\HTTP\DokuHTTPClient;
 use dokuwiki\Logger;
+use dokuwiki\Utf8\PhpString;
 
 if (!defined('DOKU_MESSAGEURL')) {
     if (in_array('ssl', stream_get_transports())) {
@@ -154,14 +154,68 @@ function getVersionData()
  * If no version can be determined "snapshot? update version XX" is returned.
  * Where XX represents the update version number set in doku.php.
  *
- * @author Anika Henke <anika@selfthinker.org>
  * @return string The version string e.g. "Release 2023-04-04a"
+ * @author Anika Henke <anika@selfthinker.org>
  */
 function getVersion()
 {
     $version = getVersionData();
     $sha = empty($version['sha']) ? '' : ' (' . $version['sha'] . ')';
     return $version['type'] . ' ' . $version['date'] . $sha;
+}
+
+/**
+ * Get some data about the environment this wiki is running in
+ *
+ * @return array
+ */
+function getRuntimeVersions()
+{
+    $data = [];
+    $data['php'] = 'PHP ' . PHP_VERSION;
+
+    $osRelease = getOsRelease();
+    if (isset($osRelease['PRETTY_NAME'])) {
+        $data['dist'] = $osRelease['PRETTY_NAME'];
+    }
+
+    $data['os'] = php_uname('s') . ' ' . php_uname('r');
+    $data['sapi'] = PHP_SAPI;
+
+    if (getenv('KUBERNETES_SERVICE_HOST')) {
+        $data['container'] = 'Kubernetes';
+    } elseif (file_exists('/.dockerenv')) {
+        $data['container'] = 'Docker';
+    }
+
+    return $data;
+}
+
+/**
+ * Get informational data about the linux distribution this wiki is running on
+ *
+ * @see https://gist.github.com/natefoo/814c5bf936922dad97ff
+ * @return array an os-release array, might be empty
+ */
+function getOsRelease()
+{
+    $osRelease = [];
+    if (file_exists('/etc/os-release')) {
+        // pretty much any common Linux distribution has this
+        $osRelease = parse_ini_file('/etc/os-release');
+    } elseif (file_exists('/etc/synoinfo.conf') && file_exists('/etc/VERSION')) {
+        // Synology DSM has its own way
+        $synoInfo = parse_ini_file('/usr/lib/synoinfo.conf');
+        $synoVersion = parse_ini_file('/etc/VERSION');
+        $osRelease['NAME'] = 'Synology DSM';
+        $osRelease['ID'] = 'synology';
+        $osRelease['ID_LIKE'] = 'linux';
+        $osRelease['VERSION_ID'] = $synoVersion['productversion'];
+        $osRelease['VERSION'] = $synoVersion['productversion'];
+        $osRelease['SYNO_MODEL'] = $synoInfo['upnpmodelname'];
+        $osRelease['PRETTY_NAME'] = join(' ', [$osRelease['NAME'], $osRelease['VERSION'], $osRelease['SYNO_MODEL']]);
+    }
+    return $osRelease;
 }
 
 /**


### PR DESCRIPTION
Bug reports are often lacking crucial information about the environment the wiki is run on and novice users often do not know how to obtain this data.

This patch gathers some environmental information and outputs it next to the DokuWiki version number on the admin screen.

Info included (if obtainable):

* PHP version
* Linux Distribution name and version
* Operating System and Version (refers to kernel version on linux)
* The PHP SAPI (modphp, cgi, fcgi)
* If running on kubernetes or docker