### PR TITLE
align url for several lib/plugin members 

### DIFF
--- a/lib/plugins/acl/plugin.info.txt
+++ b/lib/plugins/acl/plugin.info.txt
@@ -4,4 +4,4 @@ email  andi@splitbrain.org
 date   2015-07-25
 name   ACL Manager
 desc   Manage Page Access Control Lists
-url    http://dokuwiki.org/plugin:acl
+url    https://www.dokuwiki.org/plugin:acl

--- a/lib/plugins/authad/plugin.info.txt
+++ b/lib/plugins/authad/plugin.info.txt
@@ -4,4 +4,4 @@ email  andi@splitbrain.org
 date   2015-07-13
 name   Active Directory Auth Plugin
 desc   Provides user authentication against a Microsoft Active Directory
-url    http://www.dokuwiki.org/plugin:authad
+url    https://www.dokuwiki.org/plugin:authad

--- a/lib/plugins/authldap/plugin.info.txt
+++ b/lib/plugins/authldap/plugin.info.txt
@@ -4,4 +4,4 @@ email  andi@splitbrain.org
 date   2015-07-13
 name   LDAP Auth Plugin
 desc   Provides user authentication against an LDAP server
-url    http://www.dokuwiki.org/plugin:authldap
+url    https://www.dokuwiki.org/plugin:authldap

--- a/lib/plugins/authplain/plugin.info.txt
+++ b/lib/plugins/authplain/plugin.info.txt
@@ -4,4 +4,4 @@ email  andi@splitbrain.org
 date   2015-07-18
 name   Plain Auth Plugin
 desc   Provides user authentication against DokuWiki's local password storage
-url    http://www.dokuwiki.org/plugin:authplain
+url    https://www.dokuwiki.org/plugin:authplain

--- a/lib/plugins/extension/_test/extension.test.php
+++ b/lib/plugins/extension/_test/extension.test.php
@@ -51,7 +51,7 @@ class helper_plugin_extension_extension_test extends DokuWikiTest {
         $this->assertEquals('Tobias Sarnowski', $extension->getAuthor());
         $this->assertEquals('tobias@trustedco.de', $extension->getEmail());
         $this->assertEquals(md5('tobias@trustedco.de'), $extension->getEmailID());
-        $this->assertEquals('http://www.dokuwiki.org/plugin:testing', $extension->getURL());
+        $this->assertEquals('https://www.dokuwiki.org/plugin:testing', $extension->getURL());
         $this->assertEquals('Used to test the test framework. Should always be disabled.', $extension->getDescription());
         $this->assertFalse($extension->isTemplate());
         $this->assertFalse($extension->isEnabled());

--- a/lib/plugins/info/plugin.info.txt
+++ b/lib/plugins/info/plugin.info.txt
@@ -1,7 +1,7 @@
-base info
+base   info
 author Andreas Gohr
-email andi@splitbrain.org
-date 2020-06-04
-name Info Plugin
-desc Displays information about various DokuWiki internals
-url http://dokuwiki.org/plugin:info
+email  andi@splitbrain.org
+date   2020-06-04
+name   Info Plugin
+desc   Displays information about various DokuWiki internals
+url    https://www.dokuwiki.org/plugin:info

--- a/lib/plugins/popularity/plugin.info.txt
+++ b/lib/plugins/popularity/plugin.info.txt
@@ -1,7 +1,7 @@
-base    popularity
-author  Andreas Gohr
-email   andi@splitbrain.org
-date    2015-07-15
-name    Popularity Feedback Plugin
-desc    Send anonymous data about your wiki to the DokuWiki developers
-url     http://www.dokuwiki.org/plugin:popularity
+base   popularity
+author Andreas Gohr
+email  andi@splitbrain.org
+date   2015-07-15
+name   Popularity Feedback Plugin
+desc   Send anonymous data about your wiki to the DokuWiki developers
+url    https://www.dokuwiki.org/plugin:popularity

--- a/lib/plugins/revert/plugin.info.txt
+++ b/lib/plugins/revert/plugin.info.txt
@@ -4,4 +4,4 @@ email  andi@splitbrain.org
 date   2015-07-15
 name   Revert Manager
 desc   Allows you to mass revert recent edits to remove Spam or vandalism
-url    http://dokuwiki.org/plugin:revert
+url    https://dokuwiki.org/plugin:revert

--- a/lib/plugins/safefnrecode/plugin.info.txt
+++ b/lib/plugins/safefnrecode/plugin.info.txt
@@ -4,4 +4,4 @@ email  andi@splitbrain.org
 date   2012-07-28
 name   safefnrecode plugin
 desc   Changes existing page and foldernames for the change in the safe filename encoding
-url    http://www.dokuwiki.org/plugin:safefnrecode
+url    https://www.dokuwiki.org/plugin:safefnrecode

--- a/lib/plugins/testing/plugin.info.txt
+++ b/lib/plugins/testing/plugin.info.txt
@@ -4,4 +4,4 @@ email  tobias@trustedco.de
 date   2012-07-28
 name   Testing Plugin
 desc   Used to test the test framework. Should always be disabled.
-url    http://www.dokuwiki.org/plugin:testing
+url    https://www.dokuwiki.org/plugin:testing

--- a/lib/plugins/usermanager/plugin.info.txt
+++ b/lib/plugins/usermanager/plugin.info.txt
@@ -4,4 +4,4 @@ email  chris@jalakai.co.uk
 date   2015-07-15
 name   User Manager
 desc   Manage DokuWiki user accounts
-url    http://dokuwiki.org/plugin:usermanager
+url    https://www.dokuwiki.org/plugin:usermanager


### PR DESCRIPTION
ref https://github.com/dokuwiki/dokuwiki/issues/4270

- align url of respective `plugin.info.txt` to standard prefix
- realign spacing as applicable