### PR TITLE
Improving CLI extension list display

### DIFF
--- a/lib/plugins/extension/cli.php
+++ b/lib/plugins/extension/cli.php
@@ -327,23 +327,30 @@ class cli_plugin_extension extends CLIPlugin
         $ext = $this->loadHelper('extension_extension');
         $tr = new TableFormatter($this->colors);
 
-
         foreach ($list as $name) {
             $ext->setExtension($name);
 
-            $status = '';
             if ($ext->isInstalled()) {
                 $date = $ext->getInstalledVersion();
                 $avail = $ext->getLastUpdate();
-                $status = 'i';
-                if ($avail && $avail > $date) {
-                    $vcolor = Colors::C_RED;
-                    $status .= 'u';
+
+                if ($ext->isBundled()) {
+                    $status = 'b';
+                    $vcolor = Colors::C_RESET;
                 } else {
-                    $vcolor = Colors::C_GREEN;
+                    if ($ext->isGitControlled()) {
+                        $status = 'g';
+                    } else {
+                        $status = 'i';
+                    }
+                    if ($avail && $avail > $date) {
+                        $vcolor = Colors::C_RED;
+                        $status .= 'u';
+                    } else {
+                        $vcolor = Colors::C_GREEN;
+                    }
                 }
-                if ($ext->isGitControlled()) $status = 'g';
-                if ($ext->isBundled()) $status = 'b';
+
                 if ($ext->isEnabled()) {
                     $ecolor = Colors::C_BROWN;
                 } else {
@@ -351,6 +358,7 @@ class cli_plugin_extension extends CLIPlugin
                     $status .= 'd';
                 }
             } else {
+                $status = '';
                 $ecolor = null;
                 $date = $ext->getLastUpdate();
                 $vcolor = null;

--- a/lib/plugins/extension/cli.php
+++ b/lib/plugins/extension/cli.php
@@ -326,6 +326,7 @@ class cli_plugin_extension extends CLIPlugin
         /** @var helper_plugin_extension_extension $ext */
         $ext = $this->loadHelper('extension_extension');
         $tr = new TableFormatter($this->colors);
+        $dw_release_date = getVersionData()['date'];
 
         foreach ($list as $name) {
             $ext->setExtension($name);
@@ -337,6 +338,8 @@ class cli_plugin_extension extends CLIPlugin
                 if ($ext->isBundled()) {
                     $status = 'b';
                     $vcolor = Colors::C_RESET;
+                    // Use DokuWiki release date for bundled plugins
+                    $date = $dw_release_date;
                 } else {
                     if ($ext->isGitControlled()) {
                         $status = 'g';

--- a/lib/plugins/extension/cli.php
+++ b/lib/plugins/extension/cli.php
@@ -352,9 +352,9 @@ class cli_plugin_extension extends CLIPlugin
                 }
 
                 if ($ext->isEnabled()) {
-                    $ecolor = Colors::C_BROWN;
+                    $ecolor = Colors::C_RESET;
                 } else {
-                    $ecolor = Colors::C_DARKGRAY;
+                    $ecolor = Colors::C_BLUE;
                     $status .= 'd';
                 }
             } else {


### PR DESCRIPTION
This PR includes the following changes to the CLI `extension list` command:

- Bundled plugins are by definition never outdated, so they should not be shown in red.
- Adjusted colors for extension name
  - Using default color for enabled extensions (no reason to light up the screen like a Xmas tree)
  - Use blue for disabled ones, as dark grey was hard to read on terminals with black background.
 - Display DokuWiki release date instead of the one from plugin.info.txt for Bundled plugins

Follows discussion with @andi in https://forum.dokuwiki.org/d/22141-extension-plugin-cli-confused-by-list-command-output.

## Before
![image](https://github.com/dokuwiki/dokuwiki/assets/449891/0b547038-74b9-437a-9777-dc99f80290a5)

## After
![image](https://github.com/dokuwiki/dokuwiki/assets/449891/d4bd8720-db5a-402e-8295-4960946bfd09)
