### PR TITLE
Support Woltlab password hashes

### DIFF
--- a/_test/tests/inc/auth_password.test.php
+++ b/_test/tests/inc/auth_password.test.php
@@ -143,4 +143,8 @@ class auth_password_test extends DokuWikiTest {
         }
     }
 
+    function test_verifyPassword_Woltlab()
+    {
+        $this->assertTrue(auth_verifyPassword('zQ9ZwsTvgufN', 'Bcrypt:$2y$12$ygz.4TeGn/NXEcXIE0pyge4lJyuSMqRdDPT5dW469lODb.HswSzjW'));
+    }
 }

--- a/inc/PassHash.php
+++ b/inc/PassHash.php
@@ -79,7 +79,10 @@ class PassHash
             $salt   = $m[1];
         } elseif (preg_match('/^\$2([abxy])\$(.{2})\$/', $hash, $m)) {
             $method = 'bcrypt';
-            $salt   = $hash;
+            $salt = $hash;
+        } elseif (str_starts_with($hash, 'Bcrypt:$2')) {
+            $method = 'woltlab';
+            $salt = substr($hash, 7);
         } elseif (str_starts_with($hash, '{SSHA}')) {
             $method = 'ssha';
             $salt   = substr(base64_decode(substr($hash, 6)), 20);
@@ -683,6 +686,21 @@ class PassHash
         }
 
         return crypt($clear, $salt);
+    }
+
+    /**
+     * Password hashing method 'woltlab'
+     *
+     * Woltlab forums use a bcrypt hash with a custom prefix.
+     *
+     * @param $clear
+     * @param $salt
+     * @return string
+     * @throws \Exception
+     */
+    public function hash_woltlab($clear, $salt = null)
+    {
+        return 'Bcrypt:' . $this->hash_bcrypt($clear, $salt);
     }
 
     /**


### PR DESCRIPTION
The Woltlab forum software uses bcrypt passwords, but prefixes them with "Bcrypt:". This adds support for this in our PassHash class.