### PR TITLE
Move JWT token into metadir #4239

### DIFF
--- a/inc/JWT.php
+++ b/inc/JWT.php
@@ -179,6 +179,10 @@ class JWT
      */
     public static function getStorageFile($user)
     {
-        return getCacheName($user, '.token');
+        global $conf;
+        $hash = hash('sha256', $user);
+        $file = $conf['metadir'] . '/jwt/' . $hash[0] . '/' . $hash . '.token';
+        io_makeFileDir($file);
+        return $file;
     }
 }


### PR DESCRIPTION
Moving JWT token store away from cache directory, to have long-lived authentication files properly stored. Implementing request #4239 

Using sha256 on the files instead of md5, to help mitigate potential hash collision as filenames are based on username.

I opted against making a new function inside inc/pageutils.php, as I did not see much value, given jwt tokens are best inside a dedicated subfolder.