### PR TITLE
alternative token header support

### DIFF
--- a/_test/tests/inc/JWTTest.php
+++ b/_test/tests/inc/JWTTest.php
@@ -79,4 +79,14 @@ class JWTTest extends \DokuWikiTest
         $this->assertEquals('testuser', $_SERVER['REMOTE_USER']);
         unset($_SERVER['HTTP_AUTHORIZATION']);
     }
+
+    public function testLoginAlternativeHeader()
+    {
+        $_SERVER['HTTP_X-DOKUWIKI-TOKEN'] =  JWT::fromUser('testuser')->getToken();
+
+        $this->assertArrayNotHasKey('REMOTE_USER', $_SERVER);
+        auth_tokenlogin();
+        $this->assertEquals('testuser', $_SERVER['REMOTE_USER']);
+        unset($_SERVER['HTTP_X-DOKUWIKI-TOKEN']);
+    }
 }


### PR DESCRIPTION
The Authorization header is not always passed on to PHP, depending on the setup (See https://stackoverflow.com/q/34472303 for examples and workarounds).

This patch adds support for an alternative X-DokuWiki-Token header that can be used when using token authentication and the standard Authorization header can not be used.