### PR TITLE
Very minor performance nit in AbstractAction constructor

### DIFF
--- a/inc/Action/AbstractAction.php
+++ b/inc/Action/AbstractAction.php
@@ -28,8 +28,7 @@ abstract class AbstractAction
             $this->actionname = $actionname;
         } else {
             // As of PHP 8 this seems to be the fastest way to get the name:
-            $n = explode('\\', get_class($this));
-            $this->actionname = strtolower(array_pop($n));
+            $this->actionname = strtolower((new \ReflectionClass($this))->getShortName());
         }
     }
 

--- a/inc/Action/AbstractAction.php
+++ b/inc/Action/AbstractAction.php
@@ -29,7 +29,7 @@ abstract class AbstractAction
         } else {
             // As of PHP 8 this seems to be the fastest way to get the name:
             $n = explode('\\', get_class($this));
-            $this->actionname = array_pop($n);
+            $this->actionname = strtolower(array_pop($n));
         }
     }
 

--- a/inc/Action/AbstractAction.php
+++ b/inc/Action/AbstractAction.php
@@ -27,8 +27,9 @@ abstract class AbstractAction
         if ($actionname !== '') {
             $this->actionname = $actionname;
         } else {
-            // http://stackoverflow.com/a/27457689/172068
-            $this->actionname = strtolower(substr(strrchr(get_class($this), '\\'), 1));
+            // As of PHP 8 this seems to be the fastest way to get the name:
+            $n = explode('\\', get_class($this));
+            $this->actionname = array_pop($n);
         }
     }
 


### PR DESCRIPTION
Note: I only touched this because of the obvious care taken to get the fastest implementation at the time this code was originally written. In the grand scheme of things it is not important ;-)

https://github.com/dokuwiki/dokuwiki/blob/a09f9f21cb0c1d60c498a0945989b20f2b3f00a7/inc/Action/AbstractAction.php#L30-L31

I tried the referenced code from stackoverflow.com with minor fixes for PHP language changes on PHP 8.2.21 and PHP 8.3.9 (Mac mini M2 Pro) and the Reflection code was now fastest:

```
Reflection: 0.007136058807373 s ClassA
Basename: 0.01236629486084 s ClassA
Explode: 0.012751793861389 s ClassA
Substring: 0.0079569101333618 s ClassA
SubstringStrCh: 0.0082878351211548 s ClassA
```
(I did several runs with both versions of PHP with similar results.)

I also tested PHP 7.4.33, PHP 8.0.30, PHP 8.1.29, PHP 8.2.22 and 8.3.10 on amd64 (VM) and all 8.x. versions had similar results. Only using PHP 7.4.33 the Reflection method was slightly slower than the SubstringStrCh method. As PHP 7.4 is EoL I think it would be fine to optimize for PHP 8.x now.

The sightly modified (because `array_pop` takes its argument by reference) code:
```php
  public function getClassExplode(){
    $n = explode('\\', get_class($this));
    $c = array_pop($n);
    return $c;
  }
```