### PR TITLE
Support a URI parameter for ldap since current code doesn't actually work

### DIFF
--- a/lib/plugins/authldap/auth.php
+++ b/lib/plugins/authldap/auth.php
@@ -551,7 +551,11 @@ class auth_plugin_authldap extends AuthPlugin
         $servers = explode(',', $this->getConf('server'));
         foreach ($servers as $server) {
             $server = trim($server);
-            $this->con = @ldap_connect($server, $port);
+            if (str_starts_with($server, 'ldap://') || str_starts_with($server, 'ldaps://')) {
+                $this->con = @ldap_connect($server);
+            } else {
+                $this->con = @ldap_connect($server, $port);
+            }
             if (!$this->con) {
                 continue;
             }


### PR DESCRIPTION
The current documentation refers to putting a uri in the 'server' attribute. That doesn't actually work since two arguments are being passed to the ldap_connect function. You can only pass a single argument if using ldap uri syntax. This adjusts the code to look for a uri and pass it in as a single argument if so.

![image](https://github.com/user-attachments/assets/fdf90c25-5e14-4e88-88dd-f85d4272ef07)
Note - above refers to 8.3 for the deprecation, but this has been broken for a LONG time going back to at least php 7.4. 
