### PR TITLE
add config option to notify self

### DIFF
--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -106,6 +106,7 @@ $conf['subscribers'] = 0;                //enable change notice subscription sup
 $conf['subscribe_time'] = 24*60*60;      //Time after which digests / lists are sent (in sec, default 1 day)
                                          //Should be smaller than the time specified in recent_days
 $conf['notify']      = '';               //send change info to this email (leave blank for nobody)
+$conf['notifyself']  = 0;                //when sending notifications to subscribers, include self
 $conf['registernotify'] = '';            //send info about newly registered users to this email (leave blank for nobody)
 $conf['mailfrom']    = '';               //use this email when sending mails
 $conf['mailreturnpath']    = '';         //use this email as returnpath for bounce mails

--- a/inc/common.php
+++ b/inc/common.php
@@ -1358,7 +1358,7 @@ function notify($id, $who, $rev = '', $summary = '', $minor = false, $replace = 
     } elseif ($who == 'subscribers') {
         if (!actionOK('subscribe')) return false; //subscribers enabled?
         if ($conf['useacl'] && $INPUT->server->str('REMOTE_USER') && $minor) return false; //skip minors
-        $data = ['id' => $id, 'addresslist' => '', 'self' => false, 'replacements' => $replace];
+        $data = ['id' => $id, 'addresslist' => '', 'self' => $conf['notifyself'], 'replacements' => $replace];
         Event::createAndTrigger(
             'COMMON_NOTIFY_ADDRESSLIST',
             $data,


### PR DESCRIPTION
Allow a wiki to be configured to send notifications to the individual making the change. Defaults to off, but this is sometimes requested. Ideally this would be a per-user preference, but this at least allows setting it globally. 