### PR TITLE
autodetect css webbase from first url within

### DIFF
--- a/inc/StyleUtils.php
+++ b/inc/StyleUtils.php
@@ -149,6 +149,22 @@ class StyleUtils
                 msg("Stylesheet $file not found, please contact the developer of \"$this->tpl\" template.", 2);
             }
         }
+        if(strpos($file,'/')!==false){
+            #detect which convention this file uses in its url's. relative to the template dir or relative to the file itself.
+            $s=file_get_contents($incbase . $file);
+            #just look at the first one.
+            if(preg_match('#(url\([ \'"]*)(?!/|data:|http://|https://| |\'|")#',$s,$m,PREG_OFFSET_CAPTURE)){
+                if(preg_match('#^url\([ \'"]*([^\)\'"]+)[ \'"]*\)#',substr($s,$m[0][1]),$m2)){
+                    $url=trim($m2[1]);
+                    #if the default convention (relative to template dir) does not work,
+                    #but the alternative convention (url is relative to the file) works.
+                    if(!file_exists($incbase . $url) && file_exists($incbase . dirname($file) . '/' . $url)){ 
+                            $webbase.=dirname($file) . '/';    
+                    } 
+                }
+            }
+        }
+
         $stylesheets[$mode][fullpath($incbase . $file)] = $webbase;
         return $stylesheets;
     }


### PR DESCRIPTION
This is in response to the issue: https://github.com/dokuwiki/dokuwiki/issues/4313#issuecomment-2282795794



This proposed PR addresses that issue, but has these limitations:
* Only the first encountered url is used to decide $webbase.
* There may be cases where the first url can be resolved in both ways. Only the file relative to the template-folder would end up being used.
* Only url() entries are used. @import statements are not considered. This is not just a problem for this function but is also an issue elsewhere.
* The entire css file is read and searched for a url, which is not efficient (compared to the alternative strategy described below).


I consider this PR a temporary hack/fix. The current DW convention is to use the template folder as the $webbase. But for each file, considering that file's folder as its $webbase would be a more intuitive solution. Such a change would break some of the existing templates. Backward compatibility can be maintained via the use of a new method/property in templates e.g., css_url_relativeto=file|template. template.info.txt seems to be a natural place to record such information. cssStyleini() is where there is knowledge about the template; that's where the value of this property can be checked and advised into getValidatedStyles() accordingly. Old templates without this property would work as they did before.