### PR TITLE
make sure stderr is defined in logger

### DIFF
--- a/inc/Logger.php
+++ b/inc/Logger.php
@@ -228,7 +228,9 @@ class Logger
     protected function writeLogLines($lines, $logfile)
     {
         if (defined('DOKU_UNITTEST')) {
-            fwrite(STDERR, "\n[" . $this->facility . '] ' . implode("\n", $lines) . "\n");
+            $stderr = fopen('php://stderr', 'w');
+            fwrite($stderr, "\n[" . $this->facility . '] ' . implode("\n", $lines) . "\n");
+            fclose($stderr);
         }
         return io_saveFile($logfile, implode("\n", $lines) . "\n", true);
     }


### PR DESCRIPTION
STDERR is only defined when PHP is called from the command line.

In the docker health check we set DOKU_UNITTEST to make sure that errors trigger exceptions instead being logged only. However when the error then is also written to STDERR it fails.

This patch makes sure the data is written to PHP's STDERR stream handler instead.

Should fix dokuwiki/docker#15