### PR TITLE
Use a dispatcher to access lib/images/

### DIFF
--- a/inc/ChangeLog/RevisionInfo.php
+++ b/inc/ChangeLog/RevisionInfo.php
@@ -113,7 +113,7 @@ class RevisionInfo
             return media_printicon($id);
         } elseif ($this->val('mode') == self::MODE_PAGE) {
             // page revision
-            return '<img class="icon" src="' . DOKU_BASE . 'lib/images/fileicons/file.png" alt="' . $id . '" />';
+            return '<img class="icon" src="' . DOKU_BASE . 'lib/exe/image.php/fileicons/file.png" alt="' . $id . '" />';
         }
     }
 
@@ -286,11 +286,11 @@ class RevisionInfo
 
         if ($href) {
             return '<a href="' . $href . '" class="diff_link">'
-                  . '<img src="' . DOKU_BASE . 'lib/images/diff.png" width="15" height="11"'
+                  . '<img src="' . DOKU_BASE . 'lib/exe/image.php/diff.png" width="15" height="11"'
                   . ' title="' . $lang['diff'] . '" alt="' . $lang['diff'] . '" />'
                   . '</a>';
         } else {
-            return '<img src="' . DOKU_BASE . 'lib/images/blank.gif" width="15" height="11" alt="" />';
+            return '<img src="' . DOKU_BASE . 'lib/exe/image.php/blank.gif" width="15" height="11" alt="" />';
         }
     }
 
@@ -322,11 +322,11 @@ class RevisionInfo
 
         if ($href) {
             return '<a href="' . $href . '" class="diff_link">'
-                  . '<img src="' . DOKU_BASE . 'lib/images/diff.png" width="15" height="11"'
+                  . '<img src="' . DOKU_BASE . 'lib/exe/image.php/diff.png" width="15" height="11"'
                   . ' title="' . $lang['diff'] . '" alt="' . $lang['diff'] . '" />'
                   . '</a>';
         } else {
-            return '<img src="' . DOKU_BASE . 'lib/images/blank.gif" width="15" height="11" alt="" />';
+            return '<img src="' . DOKU_BASE . 'lib/exe/image.php/blank.gif" width="15" height="11" alt="" />';
         }
     }
 
@@ -354,7 +354,7 @@ class RevisionInfo
             $href = wl($id, ['do' => 'revisions'], false, '&');
         }
         return '<a href="' . $href . '" class="revisions_link">'
-              . '<img src="' . DOKU_BASE . 'lib/images/history.png" width="12" height="14"'
+              . '<img src="' . DOKU_BASE . 'lib/exe/image.php/history.png" width="12" height="14"'
               . ' title="' . $lang['btn_revs'] . '" alt="' . $lang['btn_revs'] . '" />'
               . '</a>';
     }

--- a/inc/File/StaticImage.php
+++ b/inc/File/StaticImage.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace dokuwiki\File;
+
+/**
+ * Access a static file from lib/images with optinal override in conf/images
+ */
+class StaticImage
+{
+
+    protected string $path;
+
+    /**
+     * @param string $path the path relative to lib/images
+     */
+    public function __construct(string $path)
+    {
+        require_once(DOKU_INC . 'inc/fetch.functions.php'); // late load when needed
+
+        $path = preg_replace('/\.\.+/', '.', $path);
+        $path = preg_replace('/\/\/+/', '/', $path);
+        $path = trim($path, '/');
+        $this->path = $path;
+    }
+
+    /**
+     * Static convenience method to get the real path to an image
+     *
+     * @param string $path
+     * @return string
+     */
+    public static function path(string $path): string
+    {
+        return (new self($path))->getRealPath();
+    }
+
+    /**
+     * Static convenience method to get the URL to an image
+     *
+     * @param string $path
+     * @return string
+     */
+    public static function url(string $path): string
+    {
+        return (new self($path))->getURL();
+    }
+
+    /**
+     * @return string the mime type of the image
+     */
+    public function getMimeType()
+    {
+        [/*ext*/, $mime] = mimetype($this->path, false);
+        if ($mime === false) throw new \RuntimeException('Unknown mime type');
+        return $mime;
+    }
+
+    /**
+     * @return string the real path to the image
+     */
+    public function getRealPath()
+    {
+        // overridden image
+        $path = DOKU_CONF . 'images/' . $this->path;
+        if (file_exists($path)) return $path;
+
+        // default image
+        $path = DOKU_INC . 'lib/images/' . $this->path;
+        if (file_exists($path)) return $path;
+
+        throw new \RuntimeException('Image not found');
+    }
+
+    /**
+     * @return string the URL to the image
+     */
+    public function getURL()
+    {
+        return DOKU_BASE . 'lib/exe/image.php/' . $this->path;
+    }
+
+    /**
+     * Serve the image to the client
+     */
+    public function serve()
+    {
+        $path = $this->getRealPath();
+        $mime = $this->getMimeType();
+        sendFile($path, $mime, false, -1, true);
+    }
+}

--- a/inc/Menu/Item/AbstractItem.php
+++ b/inc/Menu/Item/AbstractItem.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class AbstractItem
  *
@@ -64,6 +66,7 @@ abstract class AbstractItem
         $this->id = $ID;
         $this->type = $this->getType();
         $this->params['do'] = $this->type;
+        $this->svg = StaticImage::path('menu/00-default_checkbox-blank-circle-outline.svg');
 
         if (!actionOK($this->type)) throw new \RuntimeException("action disabled: {$this->type}");
     }

--- a/inc/Menu/Item/Admin.php
+++ b/inc/Menu/Item/Admin.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class Admin
  *
@@ -14,7 +16,7 @@ class Admin extends AbstractItem
     {
         parent::__construct();
 
-        $this->svg = DOKU_INC . 'lib/images/menu/settings.svg';
+        $this->svg = StaticImage::path('menu/settings.svg');
     }
 
     /** @inheritdoc */

--- a/inc/Menu/Item/Back.php
+++ b/inc/Menu/Item/Back.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class Back
  *
@@ -24,6 +26,6 @@ class Back extends AbstractItem
         $this->id = $parent;
         $this->params = ['do' => ''];
         $this->accesskey = 'b';
-        $this->svg = DOKU_INC . 'lib/images/menu/12-back_arrow-left.svg';
+        $this->svg = StaticImage::path('menu/12-back_arrow-left.svg');
     }
 }

--- a/inc/Menu/Item/Backlink.php
+++ b/inc/Menu/Item/Backlink.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class Backlink
  *
@@ -13,6 +15,6 @@ class Backlink extends AbstractItem
     public function __construct()
     {
         parent::__construct();
-        $this->svg = DOKU_INC . 'lib/images/menu/08-backlink_link-variant.svg';
+        $this->svg = StaticImage::path('menu/08-backlink_link-variant.svg');
     }
 }

--- a/inc/Menu/Item/Edit.php
+++ b/inc/Menu/Item/Edit.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class Edit
  *
@@ -61,7 +63,7 @@ class Edit extends AbstractItem
             'source' => '05-source_file-xml.svg'
         ];
         if (isset($icons[$this->type])) {
-            $this->svg = DOKU_INC . 'lib/images/menu/' . $icons[$this->type];
+            $this->svg = StaticImage::path('menu/' . $icons[$this->type]);
         }
     }
 }

--- a/inc/Menu/Item/ImgBackto.php
+++ b/inc/Menu/Item/ImgBackto.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class ImgBackto
  *
@@ -15,7 +17,7 @@ class ImgBackto extends AbstractItem
         global $ID;
         parent::__construct();
 
-        $this->svg = DOKU_INC . 'lib/images/menu/12-back_arrow-left.svg';
+        $this->svg = StaticImage::path('menu/12-back_arrow-left.svg');
         $this->type = 'img_backto';
         $this->params = [];
         $this->accesskey = 'b';

--- a/inc/Menu/Item/Index.php
+++ b/inc/Menu/Item/Index.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class Index
  *
@@ -17,7 +19,7 @@ class Index extends AbstractItem
         parent::__construct();
 
         $this->accesskey = 'x';
-        $this->svg = DOKU_INC . 'lib/images/menu/file-tree.svg';
+        $this->svg = StaticImage::path('menu/file-tree.svg');
 
         // allow searchbots to get to the sitemap from the homepage (when dokuwiki isn't providing a sitemap.xml)
         if ($conf['start'] == $ID && !$conf['sitemap']) {

--- a/inc/Menu/Item/Login.php
+++ b/inc/Menu/Item/Login.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class Login
  *
@@ -15,7 +17,7 @@ class Login extends AbstractItem
         global $INPUT;
         parent::__construct();
 
-        $this->svg = DOKU_INC . 'lib/images/menu/login.svg';
+        $this->svg = StaticImage::path('menu/login.svg');
         $this->params['sectok'] = getSecurityToken();
         if ($INPUT->server->has('REMOTE_USER')) {
             if (!actionOK('logout')) {
@@ -23,7 +25,7 @@ class Login extends AbstractItem
             }
             $this->params['do'] = 'logout';
             $this->type = 'logout';
-            $this->svg = DOKU_INC . 'lib/images/menu/logout.svg';
+            $this->svg = StaticImage::path('menu/logout.svg');
         }
     }
 }

--- a/inc/Menu/Item/Media.php
+++ b/inc/Menu/Item/Media.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class Media
  *
@@ -15,7 +17,7 @@ class Media extends AbstractItem
         global $ID;
         parent::__construct();
 
-        $this->svg = DOKU_INC . 'lib/images/menu/folder-multiple-image.svg';
+        $this->svg = StaticImage::path('menu/folder-multiple-image.svg');
         $this->params['ns'] = getNS($ID);
     }
 }

--- a/inc/Menu/Item/MediaManager.php
+++ b/inc/Menu/Item/MediaManager.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class MediaManager
  *
@@ -21,7 +23,7 @@ class MediaManager extends AbstractItem
             throw new \RuntimeException("media manager link only with upload permissions");
         }
 
-        $this->svg = DOKU_INC . 'lib/images/menu/11-mediamanager_folder-image.svg';
+        $this->svg = StaticImage::path('menu/11-mediamanager_folder-image.svg');
         $this->type = 'mediaManager';
         $this->params = ['ns' => $imgNS, 'image' => $IMG, 'do' => 'media'];
     }

--- a/inc/Menu/Item/Profile.php
+++ b/inc/Menu/Item/Profile.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class Profile
  *
@@ -19,6 +21,6 @@ class Profile extends AbstractItem
             throw new \RuntimeException("profile is only for logged in users");
         }
 
-        $this->svg = DOKU_INC . 'lib/images/menu/account-card-details.svg';
+        $this->svg = StaticImage::path('menu/account-card-details.svg');
     }
 }

--- a/inc/Menu/Item/Recent.php
+++ b/inc/Menu/Item/Recent.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class Recent
  *
@@ -15,6 +17,6 @@ class Recent extends AbstractItem
         parent::__construct();
 
         $this->accesskey = 'r';
-        $this->svg = DOKU_INC . 'lib/images/menu/calendar-clock.svg';
+        $this->svg = StaticImage::path('menu/calendar-clock.svg');
     }
 }

--- a/inc/Menu/Item/Register.php
+++ b/inc/Menu/Item/Register.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class Register
  *
@@ -19,6 +21,6 @@ class Register extends AbstractItem
             throw new \RuntimeException("no register when already logged in");
         }
 
-        $this->svg = DOKU_INC . 'lib/images/menu/account-plus.svg';
+        $this->svg = StaticImage::path('menu/account-plus.svg');
     }
 }

--- a/inc/Menu/Item/Resendpwd.php
+++ b/inc/Menu/Item/Resendpwd.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class Resendpwd
  *
@@ -19,6 +21,6 @@ class Resendpwd extends AbstractItem
             throw new \RuntimeException("no resendpwd when already logged in");
         }
 
-        $this->svg = DOKU_INC . 'lib/images/menu/lock-reset.svg';
+        $this->svg = StaticImage::path('menu/lock-reset.svg');
     }
 }

--- a/inc/Menu/Item/Revert.php
+++ b/inc/Menu/Item/Revert.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class Revert
  *
@@ -22,6 +24,6 @@ class Revert extends AbstractItem
         }
         $this->params['rev'] = $REV;
         $this->params['sectok'] = getSecurityToken();
-        $this->svg = DOKU_INC . 'lib/images/menu/06-revert_replay.svg';
+        $this->svg = StaticImage::path('menu/06-revert_replay.svg');
     }
 }

--- a/inc/Menu/Item/Revisions.php
+++ b/inc/Menu/Item/Revisions.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class Revisions
  *
@@ -16,6 +18,6 @@ class Revisions extends AbstractItem
 
         $this->accesskey = 'o';
         $this->type = 'revs';
-        $this->svg = DOKU_INC . 'lib/images/menu/07-revisions_history.svg';
+        $this->svg = StaticImage::path('menu/07-revisions_history.svg');
     }
 }

--- a/inc/Menu/Item/Subscribe.php
+++ b/inc/Menu/Item/Subscribe.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class Subscribe
  *
@@ -19,6 +21,6 @@ class Subscribe extends AbstractItem
             throw new \RuntimeException("subscribe is only for logged in users");
         }
 
-        $this->svg = DOKU_INC . 'lib/images/menu/09-subscribe_email-outline.svg';
+        $this->svg = StaticImage::path('menu/09-subscribe_email-outline.svg');
     }
 }

--- a/inc/Menu/Item/Top.php
+++ b/inc/Menu/Item/Top.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Menu\Item;
 
+use dokuwiki\File\StaticImage;
+
 /**
  * Class Top
  *
@@ -15,7 +17,7 @@ class Top extends AbstractItem
     {
         parent::__construct();
 
-        $this->svg = DOKU_INC . 'lib/images/menu/10-top_arrow-up.svg';
+        $this->svg = StaticImage::path('menu/10-top_arrow-up.svg');
         $this->accesskey = 't';
         $this->params = ['do' => ''];
         $this->id = '#dokuwiki__top';

--- a/inc/Ui/Media/DisplayRow.php
+++ b/inc/Ui/Media/DisplayRow.php
@@ -28,12 +28,12 @@ class DisplayRow extends DisplayTile
 
         // view button
         $link = ml($id, '', true);
-        echo ' <a href="' . $link . '" target="_blank"><img src="' . DOKU_BASE . 'lib/images/magnifier.png" ' .
+        echo ' <a href="' . $link . '" target="_blank"><img src="' . DOKU_BASE . 'lib/exe/image.php/magnifier.png" ' .
             'alt="' . $lang['mediaview'] . '" title="' . $lang['mediaview'] . '" class="btn" /></a>';
 
         // mediamanager button
         $link = wl('', ['do' => 'media', 'image' => $id, 'ns' => getNS($id)]);
-        echo ' <a href="' . $link . '" target="_blank"><img src="' . DOKU_BASE . 'lib/images/mediamanager.png" ' .
+        echo ' <a href="' . $link . '" target="_blank"><img src="' . DOKU_BASE . 'lib/exe/image.php/mediamanager.png" ' .
             'alt="' . $lang['btn_media'] . '" title="' . $lang['btn_media'] . '" class="btn" /></a>';
 
         // delete button
@@ -41,7 +41,7 @@ class DisplayRow extends DisplayTile
             $link = DOKU_BASE . 'lib/exe/mediamanager.php?delete=' . rawurlencode($id) .
                 '&amp;sectok=' . getSecurityToken();
             echo ' <a href="' . $link . '" class="btn_media_delete" title="' . $id . '">' .
-                '<img src="' . DOKU_BASE . 'lib/images/trash.png" alt="' . $lang['btn_delete'] . '" ' .
+                '<img src="' . DOKU_BASE . 'lib/exe/image.php/trash.png" alt="' . $lang['btn_delete'] . '" ' .
                 'title="' . $lang['btn_delete'] . '" class="btn" /></a>';
         }
 

--- a/inc/media.php
+++ b/inc/media.php
@@ -1482,10 +1482,10 @@ function media_printicon($filename, $size = '')
 {
     [$ext] = mimetype(mediaFN($filename), false);
 
-    if (file_exists(DOKU_INC . 'lib/images/fileicons/' . $size . '/' . $ext . '.png')) {
-        $icon = DOKU_BASE . 'lib/images/fileicons/' . $size . '/' . $ext . '.png';
-    } else {
-        $icon = DOKU_BASE . 'lib/images/fileicons/' . $size . '/file.png';
+    try {
+        $icon = \dokuwiki\File\StaticImage::url('fileicons/' . $size . '/' . $ext . '.png');
+    } catch (\Exception $e) {
+        $icon = \dokuwiki\File\StaticImage::url('fileicons/' . $size . '/file.png');
     }
 
     return '<img src="' . $icon . '" alt="' . $filename . '" class="icon" />';
@@ -1754,11 +1754,11 @@ function media_nstree_li($item)
     $class = 'media level' . $item['level'];
     if ($item['open']) {
         $class .= ' open';
-        $img   = DOKU_BASE . 'lib/images/minus.gif';
+        $img   = DOKU_BASE . 'lib/exe/image.php/minus.gif';
         $alt   = '−';
     } else {
         $class .= ' closed';
-        $img   = DOKU_BASE . 'lib/images/plus.gif';
+        $img   = DOKU_BASE . 'lib/exe/image.php/plus.gif';
         $alt   = '+';
     }
     // TODO: only deliver an image if it actually has a subtree...

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -735,7 +735,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer
     public function smiley($smiley)
     {
         if (isset($this->smileys[$smiley])) {
-            $this->doc .= '<img src="' . DOKU_BASE . 'lib/images/smileys/' . $this->smileys[$smiley] .
+            $this->doc .= '<img src="' . DOKU_BASE . 'lib/exe/image.php/smileys/' . $this->smileys[$smiley] .
                 '" class="icon smiley" alt="' . $this->_xmlEntities($smiley) . '" />';
         } else {
             $this->doc .= $this->_xmlEntities($smiley);

--- a/inc/template.php
+++ b/inc/template.php
@@ -1744,7 +1744,7 @@ function tpl_getMediaFile($search, $abs = false, &$imginfo = null, $fallback = t
     if (!file_exists($file)) {
         // give result for fallback image
         if ($fallback) {
-            $file = DOKU_INC . 'lib/images/blank.gif';
+            $file = DOKU_INC . 'lib/exe/image.php/blank.gif';
             // stop process if false result is required (if $fallback is false)
         } else {
             return false;

--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -345,7 +345,7 @@ function css_interwiki()
 
     // default style
     echo 'a.interwiki {';
-    echo ' background: transparent url(' . DOKU_BASE . 'lib/images/interwiki.svg) 0 0 no-repeat;';
+    echo ' background: transparent url(' . DOKU_BASE . 'lib/exe/image.php/interwiki.svg) 0 0 no-repeat;';
     echo ' background-size: 1.2em;';
     echo ' padding: 0 0 0 1.4em;';
     echo '}';
@@ -355,7 +355,7 @@ function css_interwiki()
     foreach (array_keys($iwlinks) as $iw) {
         $class = preg_replace('/[^_\-a-z0-9]+/i', '_', $iw);
         foreach (['svg', 'png', 'gif'] as $ext) {
-            $file = 'lib/images/interwiki/' . $iw . '.' . $ext;
+            $file = 'lib/exe/image.php/interwiki/' . $iw . '.' . $ext;
 
             if (file_exists(DOKU_INC . $file)) {
                 echo "a.iw_$class {";
@@ -377,7 +377,7 @@ function css_filetypes()
 
     // default style
     echo '.mediafile {';
-    echo ' background: transparent url(' . DOKU_BASE . 'lib/images/fileicons/svg/file.svg) 0px 1px no-repeat;';
+    echo ' background: transparent url(' . DOKU_BASE . 'lib/exe/image.php/fileicons/svg/file.svg) 0px 1px no-repeat;';
     echo ' background-size: 1.2em;';
     echo ' padding-left: 1.5em;';
     echo '}';
@@ -396,7 +396,7 @@ function css_filetypes()
     foreach ($exts as $ext) {
         $class = preg_replace('/[^_\-a-z0-9]+/', '_', $ext);
         echo ".mf_$class {";
-        echo '  background-image: url(' . DOKU_BASE . 'lib/images/fileicons/svg/' . $ext . '.svg)';
+        echo '  background-image: url(' . DOKU_BASE . 'lib/exe/image.php/fileicons/svg/' . $ext . '.svg)';
         echo '}';
     }
 }

--- a/lib/exe/image.php
+++ b/lib/exe/image.php
@@ -1,0 +1,21 @@
+<?php
+
+
+use dokuwiki\File\StaticImage;
+
+if (!defined('DOKU_INC')) define('DOKU_INC', __DIR__ . '/../../');
+if (!defined('NOSESSION')) define('NOSESSION', true);
+
+require_once(DOKU_INC . 'inc/init.php');
+
+global $INPUT;
+
+$path = $INPUT->server->str('PATH_INFO');
+$image = new StaticImage($path);
+try {
+    $image->serve();
+} catch (\RuntimeException $e) {
+    http_status(404);
+    echo $e->getMessage();
+}
+

--- a/lib/images/.htaccess
+++ b/lib/images/.htaccess
@@ -1,0 +1,5 @@
+# route all requests to image.php
+<IfModule mod_rewrite.c>
+RewriteEngine on
+RewriteRule ^(.*)$ ../exe/image.php/$1 [L]
+</IfModule>

--- a/lib/plugins/acl/admin.php
+++ b/lib/plugins/acl/admin.php
@@ -537,10 +537,10 @@ class admin_plugin_acl extends AdminPlugin
         // namespace or page?
         if ($item['type'] == 'd') {
             if ($item['open']) {
-                $img = DOKU_BASE . 'lib/images/minus.gif';
+                $img = DOKU_BASE . 'lib/exe/image.php/minus.gif';
                 $alt = '−';
             } else {
-                $img = DOKU_BASE . 'lib/images/plus.gif';
+                $img = DOKU_BASE . 'lib/exe/image.php/plus.gif';
                 $alt = '+';
             }
             $ret .= '<img src="' . $img . '" alt="' . $alt . '" />';

--- a/lib/plugins/acl/script.js
+++ b/lib/plugins/acl/script.js
@@ -38,7 +38,7 @@ var dw_acl = {
 
                        toggle_display: function ($clicky, opening) {
                            $clicky.attr('src',
-                                        DOKU_BASE + 'lib/images/' +
+                                        DOKU_BASE + 'lib/exe/image.php/' +
                                         (opening ? 'minus' : 'plus') + '.gif');
                        }});
         $tree.delegate('a', 'click', dw_acl.treehandler);
@@ -63,7 +63,7 @@ var dw_acl = {
     loadinfo: function () {
         jQuery('#acl__info')
             .attr('role', 'alert')
-            .html('<img src="'+DOKU_BASE+'lib/images/throbber.gif" alt="..." />')
+            .html('<img src="'+DOKU_BASE+'lib/exe/image.php/throbber.gif" alt="..." />')
             .load(
                 DOKU_BASE + 'lib/exe/ajax.php',
                 jQuery('#acl__detail form').serialize() + '&call=plugin_acl&ajax=info'

--- a/lib/plugins/revert/admin.php
+++ b/lib/plugins/revert/admin.php
@@ -148,7 +148,7 @@ class admin_plugin_revert extends AdminPlugin
 
             echo '<a href="' . wl($recent['id'], "do=diff") . '">';
             $p = [];
-            $p['src']    = DOKU_BASE . 'lib/images/diff.png';
+            $p['src']    = DOKU_BASE . 'lib/exe/image.php/diff.png';
             $p['width']  = 15;
             $p['height'] = 11;
             $p['title']  = $lang['diff'];
@@ -159,7 +159,7 @@ class admin_plugin_revert extends AdminPlugin
 
             echo '<a href="' . wl($recent['id'], "do=revisions") . '">';
             $p = [];
-            $p['src']    = DOKU_BASE . 'lib/images/history.png';
+            $p['src']    = DOKU_BASE . 'lib/exe/image.php/history.png';
             $p['width']  = 12;
             $p['height'] = 14;
             $p['title']  = $lang['btn_revs'];

--- a/lib/scripts/edit.js
+++ b/lib/scripts/edit.js
@@ -44,7 +44,7 @@ function createToolButton(icon,label,key,id,classname){
 
     // create the icon and add it to the button
     if(icon.substr(0,1) !== '/'){
-        icon = DOKU_BASE + 'lib/images/toolbar/' + icon;
+        icon = DOKU_BASE + 'lib/exe/image.php/toolbar/' + icon;
     }
     $ico.attr('src', icon);
     $ico.attr('alt', '');
@@ -98,7 +98,7 @@ function createPicker(id,props,edid){
         if(isNaN(key)){
             // associative array -> treat as text => image pairs
             if (item.substr(0,1) !== '/') {
-                item = DOKU_BASE+'lib/images/'+props.icobase+'/'+item;
+                item = DOKU_BASE+'lib/exe/image.php/'+props.icobase+'/'+item;
             }
             jQuery(document.createElement('img'))
                 .attr('src', item)

--- a/lib/scripts/editor.js
+++ b/lib/scripts/editor.js
@@ -58,7 +58,7 @@ var dw_editor = {
             ['wrap', function(){dw_editor.toggleWrap(editor);}]
         ], function (_, img) {
             jQuery(document.createElement('img'))
-                .attr('src', DOKU_BASE+'lib/images/' + img[0] + '.gif')
+                .attr('src', DOKU_BASE+'lib/exe/image.php/' + img[0] + '.gif')
                 .attr('alt', '')
                 .on('click', img[1])
                 .appendTo($ctl);

--- a/lib/scripts/linkwiz.js
+++ b/lib/scripts/linkwiz.js
@@ -293,7 +293,7 @@ var dw_linkwiz = {
     autocomplete_exec: function(){
         var $res = jQuery(dw_linkwiz.result);
         dw_linkwiz.deselect();
-        $res.html('<img src="'+DOKU_BASE+'lib/images/throbber.gif" alt="" width="16" height="16" />')
+        $res.html('<img src="'+DOKU_BASE+'lib/exe/image.php/throbber.gif" alt="" width="16" height="16" />')
             .load(
             DOKU_BASE + 'lib/exe/ajax.php',
             {

--- a/lib/scripts/media.js
+++ b/lib/scripts/media.js
@@ -62,7 +62,7 @@ var dw_mediamanager = {
             },
 
             toggle_display: function ($clicky, opening) {
-                $clicky.attr('src', DOKU_BASE + 'lib/images/' + (opening ? 'minus' : 'plus') + '.gif');
+                $clicky.attr('src', DOKU_BASE + 'lib/exe/image.php/' + (opening ? 'minus' : 'plus') + '.gif');
             }
         });
         $tree.on('click', 'a', dw_mediamanager.list);
@@ -198,7 +198,7 @@ var dw_mediamanager = {
                     .on('click', bind(dw_mediamanager.setOpt, opt.id));
 
                 $img = jQuery(document.createElement('img'))
-                    .attr('src', DOKU_BASE + 'lib/images/media_' + opt.id + '_' + text + '.png');
+                    .attr('src', DOKU_BASE + 'lib/exe/image.php/media_' + opt.id + '_' + text + '.png');
 
                 $btn.append($img);
                 $p.append($btn);
@@ -472,7 +472,7 @@ var dw_mediamanager = {
         if ($container.length === 0) {
             $container = $content;
         }
-        $container.html('<img src="' + DOKU_BASE + 'lib/images/throbber.gif" alt="..." class="load" />');
+        $container.html('<img src="' + DOKU_BASE + 'lib/exe/image.php/throbber.gif" alt="..." class="load" />');
     },
 
     window_resize: function () {

--- a/lib/scripts/tree.js
+++ b/lib/scripts/tree.js
@@ -81,7 +81,7 @@ jQuery.fn.dw_tree = function(overrides) {
             $listitem.append($sublist);
 
             timeout = window.setTimeout(
-                bind(show_sublist, '<li aria-busy="true"><img src="' + DOKU_BASE + 'lib/images/throbber.gif" alt="loading..." title="loading..." /></li>'), dw_tree.throbber_delay);
+                bind(show_sublist, '<li aria-busy="true"><img src="' + DOKU_BASE + 'lib/exe/image.php/throbber.gif" alt="loading..." title="loading..." /></li>'), dw_tree.throbber_delay);
 
             dw_tree.load_data(function (data) {
                                   window.clearTimeout(timeout);


### PR DESCRIPTION
This has been accidentally pushed to master. So it was reverted in e44b94a4bd0679ff22e14add34b60590fe7077d3 which this now reverts again.

The actual changes are in e44b94a4bd0679ff22e14add34b60590fe7077d3

The idea is to use a PHP dispatcher to access all static images, including smileys and interwiki images. This way we can check `conf/images` for custom ones. This addresses dokuwiki/docker#16