### PR TITLE
Check security token for media restore. fix #4323

### DIFF
--- a/lib/exe/mediamanager.php
+++ b/lib/exe/mediamanager.php
@@ -99,7 +99,7 @@ if ($IMG && ($INPUT->str('mediado') == 'save' || @array_key_exists('save', $INPU
 
 if ($INPUT->int('rev') && $conf['mediarevisions']) $REV = $INPUT->int('rev');
 
-if ($INPUT->str('mediado') == 'restore' && $conf['mediarevisions']) {
+if ($INPUT->str('mediado') == 'restore' && $conf['mediarevisions'] && checkSecurityToken()) {
     $JUMPTO = media_restore($INPUT->str('image'), $REV, $AUTH);
 }
 


### PR DESCRIPTION
The whole media management is a mess, but this should fix the issue for now.

I think the severity is low since, this will only restore previously uploaded media files, so permissions need to be high enogh for upload anyway.