### PR TITLE
LinkWizard: fix multilevel parents in references

### DIFF
--- a/lib/scripts/linkwiz.js
+++ b/lib/scripts/linkwiz.js
@@ -398,7 +398,7 @@ class LinkWizard {
                     // namespaces are irrelevant
                 } else if (commonPrefixLength < sourceNs.length) {
                     // add .. for each missing namespace from common to the target
-                    relativeID.push('..'.repeat(sourceNs.length - commonPrefixLength));
+                    relativeID.push(...Array(sourceNs.length - commonPrefixLength).fill('..'));
                 } else {
                     // target is below common prefix, add .
                     relativeID.push('.');

--- a/lib/scripts/linkwiz.test.js
+++ b/lib/scripts/linkwiz.test.js
@@ -17,6 +17,7 @@ function runLinkWizardTests() {
         { ref: 'a', id: 'a:b:c', expected: 'a:b:c' },
         { ref: 'a:b', id: 'c:d', expected: 'c:d' },
         { ref: 'a:b:c', id: 'a:d:e', expected: '..:d:e' },
+        { ref: 'a:b:c:d', id: 'a:d:e', expected: '..:..:d:e' },
         { ref: 'a:b', id: 'c', expected: ':c' },
     ];
 


### PR DESCRIPTION
Fixes missing `:` separator in multiple parent namespaces, like `..:..:x` instead of incorrect `....:x`