### PR TITLE
Footnotes code changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,3 @@ phpunit.phar
 *.phpunit.result.cache
 _test/data/
 _test/.rector-cache/
-/conf
-lib/exe/php_errors.log
-php_errors.log

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ phpunit.phar
 *.phpunit.result.cache
 _test/data/
 _test/.rector-cache/
+/conf
+lib/exe/php_errors.log
+php_errors.log

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -165,8 +165,8 @@ class Doku_Renderer_xhtml extends Doku_Renderer
 
                     foreach ($alt as $ref) {
                         // set anchor and backlink for the other footnotes
-                        $this->doc .= ', <a href="#fnt__' . ($ref) . '" id="fn__' . ($ref) . '" class="fn_bot">';
-                        $this->doc .= ($ref) . '</a> ' . DOKU_LF;
+                        $this->doc .= ', <a href="#fnt__' . ($ref) . '" id="fn__' . ($ref) . '" class="fn_bot" data-value="' . $id . '"><span>';
+                        $this->doc .= ($ref) . '</span></a> ' . DOKU_LF;
                     }
 
                     // add footnote markup and close this footnote
@@ -489,7 +489,8 @@ class Doku_Renderer_xhtml extends Doku_Renderer
 
         // output the footnote reference and link
         $this->doc .= sprintf(
-            '<a href="#fn__%d" id="fnt__%d" class="fn_top">%d</a>',
+            '<a href="#fn__%d" id="fnt__%d" class="fn_top" data-value="%d"><span>%d</span></a>',
+            $fnid,
             $fnid,
             $fnid,
             $fnid

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -157,16 +157,16 @@ class Doku_Renderer_xhtml extends Doku_Renderer
                 if (!str_starts_with($footnote, "@@FNT")) {
                     // open the footnote and set the anchor and backlink
                     $this->doc .= '<div class="fn">';
-                    $this->doc .= '<sup><a href="#fnt__' . $id . '" id="fn__' . $id . '" class="fn_bot">';
-                    $this->doc .= $id . ')</a></sup> ' . DOKU_LF;
+                    $this->doc .= '<a href="#fnt__' . $id . '" id="fn__' . $id . '" class="fn_bot">';
+                    $this->doc .= $id . '</a> ' . DOKU_LF;
 
                     // get any other footnotes that use the same markup
                     $alt = array_keys($this->footnotes, "@@FNT$id");
 
                     foreach ($alt as $ref) {
                         // set anchor and backlink for the other footnotes
-                        $this->doc .= ', <sup><a href="#fnt__' . ($ref) . '" id="fn__' . ($ref) . '" class="fn_bot">';
-                        $this->doc .= ($ref) . ')</a></sup> ' . DOKU_LF;
+                        $this->doc .= ', <a href="#fnt__' . ($ref) . '" id="fn__' . ($ref) . '" class="fn_bot">';
+                        $this->doc .= ($ref) . '</a> ' . DOKU_LF;
                     }
 
                     // add footnote markup and close this footnote
@@ -489,7 +489,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer
 
         // output the footnote reference and link
         $this->doc .= sprintf(
-            '<sup><a href="#fn__%d" id="fnt__%d" class="fn_top">%d)</a></sup>',
+            '<a href="#fn__%d" id="fnt__%d" class="fn_top">%d</a>',
             $fnid,
             $fnid,
             $fnid

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -165,7 +165,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer
 
                     foreach ($alt as $ref) {
                         // set anchor and backlink for the other footnotes
-                        $this->doc .= ', <a href="#fnt__' . ($ref) . '" id="fn__' . ($ref) . '" class="fn_bot" data-value="' . $id . '"><span>';
+                        $this->doc .= ', <a href="#fnt__' . ($ref) . '" id="fn__' . ($ref) . '" class="fn_bot" data-value="' . $ref . '"><span>';
                         $this->doc .= ($ref) . '</span></a> ' . DOKU_LF;
                     }
 

--- a/lib/tpl/dokuwiki/css/_footnotes.css
+++ b/lib/tpl/dokuwiki/css/_footnotes.css
@@ -5,8 +5,15 @@
 /*____________ footnotes inside the text ____________*/
 
 /* link to footnote inside the text */
-.dokuwiki sup a.fn_top {
+.dokuwiki a.fn_top {
+    font-weight: bold;
+	vertical-align: super;
+	font-size: 66.7%;
 }
+.dokuwiki a.fn_top::after {
+	content: ')';
+}
+
 /* JSpopup */
 div.insitu-footnote {
     max-width: 40%;
@@ -26,6 +33,11 @@ div.insitu-footnote {
 .dokuwiki div.footnotes div.fn div.content {
     display: inline;
 }
-.dokuwiki div.footnotes div.fn sup a.fn_bot {
+.dokuwiki div.footnotes div.fn a.fn_bot {
     font-weight: bold;
+	vertical-align: super;
+	font-size: 66.7%;
+}
+.dokuwiki div.footnotes div.fn a.fn_bot::after {
+	content: ')';
 }

--- a/lib/tpl/dokuwiki/css/_footnotes.css
+++ b/lib/tpl/dokuwiki/css/_footnotes.css
@@ -19,7 +19,6 @@ div.insitu-footnote {
     max-width: 40%;
     min-width: 5em;
 }
-
 /*____________ footnotes at the bottom of the page ____________*/
 
 .dokuwiki div.footnotes {
@@ -28,15 +27,8 @@ div.insitu-footnote {
     margin: 1em 0 0 0;
     clear: both;
 }
-.dokuwiki div.footnotes div.fn {
-}
 .dokuwiki div.footnotes div.fn div.content {
     display: inline;
-}
-.dokuwiki div.footnotes div.fn a.fn_bot {
-    font-weight: bold;
-	vertical-align: super;
-	font-size: 66.7%;
 }
 .dokuwiki div.footnotes div.fn a.fn_bot::after {
 	content: ')';


### PR DESCRIPTION
Proposed solution for issue #4333.

This change removes the hard-coded superscript and closing brackets around footnote numbers, thus allowing templates and/or user-CSS to change the style, if needed.