### PR TITLE
Breadcrumbs a11y

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -806,19 +806,17 @@ function tpl_breadcrumbs($sep = null, $return = false)
 
     $crumbs = breadcrumbs(); //setup crumb trace
 
-    $crumbs_sep = ' <span class="bcsep">' . $sep . '</span> ';
-
     //render crumbs, highlight the last one
-    $out .= '<span class="bchead">' . $lang['breadcrumb'] . '</span>';
+    $out .= '<h2 class="bchead">' . $lang['breadcrumb'] . '</h2><ol reversed>';
     $last = count($crumbs);
     $i = 0;
     foreach ($crumbs as $id => $name) {
         $i++;
-        $out .= $crumbs_sep;
-        if ($i == $last) $out .= '<span class="curid">';
+        $out .= '<li' . ($i == $last ? ' class="curid" aria-current="page"' : '') . '>';
         $out .= '<bdi>' . tpl_link(wl($id), hsc($name), 'class="breadcrumbs" title="' . $id . '"', true) . '</bdi>';
-        if ($i == $last) $out .= '</span>';
+        if ($i == $last) $out .= '</li>';
     }
+	$out .= '</ol>';
     if ($return) return $out;
     echo $out;
     return (bool)$out;
@@ -857,10 +855,10 @@ function tpl_youarehere($sep = null, $return = false)
     $parts = explode(':', $ID);
     $count = count($parts);
 
-    $out .= '<span class="bchead">' . $lang['youarehere'] . ' </span>';
+    $out .= '<h2 class="bchead">' . $lang['youarehere'] . ' </h2>';
 
     // always print the startpage
-    $out .= '<span class="home">' . tpl_pagelink(':' . $conf['start'], null, true) . '</span>';
+    $out .= '<ol><li class="home">' . tpl_pagelink(':' . $conf['start'], null, true) . '</li>';
 
     // print intermediate namespace links
     $part = '';
@@ -870,7 +868,7 @@ function tpl_youarehere($sep = null, $return = false)
         if ($page == $conf['start']) continue; // Skip startpage
 
         // output
-        $out .= $sep . tpl_pagelink($page, null, true);
+        $out .= '<li>' . tpl_pagelink($page, null, true) . '</li>';
     }
 
     // print current page, skipping start page, skipping for namespace index
@@ -888,8 +886,7 @@ function tpl_youarehere($sep = null, $return = false)
         echo $out;
         return true;
     }
-    $out .= $sep;
-    $out .= tpl_pagelink($page, null, true);
+    $out .= '<li aria-current="page">' . tpl_pagelink($page, null, true) . '</li></ol>';
     if ($return) return $out;
     echo $out;
     return (bool)$out;

--- a/lib/tpl/dokuwiki/css/design.less
+++ b/lib/tpl/dokuwiki/css/design.less
@@ -172,9 +172,62 @@ form.search {
 .dokuwiki div.breadcrumbs {
     border-top: 1px solid @ini_border;
     border-bottom: 1px solid @ini_background;
-    margin-bottom: .5em;
     font-size: 0.875em;
     clear: both;
+
+	.youarehere, .trace {
+		& {
+			display: grid;
+			grid-template-columns: min-content auto;
+			max-width: 100%;
+			overflow: hidden;
+		}
+
+		h2 {
+			display: inline;
+			font-size: 1em;
+			font-weight: normal;
+			margin: 0; padding: 0;
+		    line-height: 1.5rem;
+			white-space: nowrap;
+		}
+		ol {
+			& {
+				display: inline-flex;
+				list-style: none inside;
+				max-width: 100%;
+				overflow: hidden;
+				margin: 0; padding: 0 .5em;
+				line-height: 1.5rem;
+			}
+			li {
+				& {
+					display: inline-block;
+					margin: 0;
+					white-space: nowrap;
+					overflow: hidden;
+					width: auto;
+					text-overflow: ellipsis;
+				}
+				&:first-child,
+				&:last-child {
+					min-width: fit-content;
+				}
+				&::before {
+					content: '\00B7';
+					display: inline-block;
+					width: 1em;
+					text-align: center;
+				}
+				&:first-child::before {
+					content: none;
+				}
+			}
+		}
+	}
+	.youarehere ol li::before {
+		content: '\203A';
+	}
 
     div {
         padding: .1em .35em;

--- a/lib/tpl/dokuwiki/tpl_header.php
+++ b/lib/tpl/dokuwiki/tpl_header.php
@@ -76,13 +76,13 @@ if (!defined('DOKU_INC')) die();
     <?php if ($conf['breadcrumbs'] || $conf['youarehere']) : ?>
         <div class="breadcrumbs">
             <?php if ($conf['youarehere']) : ?>
-                <div class="youarehere"><?php tpl_youarehere() ?></div>
+                <nav class="youarehere"><?php tpl_youarehere() ?></nav>
             <?php endif ?>
             <?php if ($conf['breadcrumbs']) : ?>
-                <div class="trace"><?php tpl_breadcrumbs() ?></div>
+                <nav class="trace"><?php tpl_breadcrumbs() ?></nav>
             <?php endif ?>
         </div>
     <?php endif ?>
 
-    <hr class="a11y" />
+    <hr class="xxa11y" />
 </div></header><!-- /header -->

--- a/lib/tpl/dokuwiki/tpl_header.php
+++ b/lib/tpl/dokuwiki/tpl_header.php
@@ -84,5 +84,5 @@ if (!defined('DOKU_INC')) die();
         </div>
     <?php endif ?>
 
-    <hr class="xxa11y" />
+    <hr class="a11y" />
 </div></header><!-- /header -->


### PR DESCRIPTION
Changes to the breadcrumbs code to improve accessibility (and a couple of other issues), as discussed in issue #4337.

The new HTML structure will look like this:
![image](https://github.com/user-attachments/assets/3b531ef7-15a2-48e7-962c-de85b9b51c26)

In addition, this adds a small update to the CSS of the breadcrumbs lists that uses flexbox CSS to make sure the items stay in one line, and if the space is not sufficient, the middle (!) items are shortened, so that the first and last items are always fully visible.

Here is a screenshot of the rendered breadcrumb with the middle item shortened:
![image](https://github.com/user-attachments/assets/80e7a926-4a9b-4a81-8b8b-4b62d9d3ec74)
