### PR TITLE
Semantic markup for Last Modified field

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -948,7 +948,8 @@ function tpl_pageinfo($ret = false)
         }
     }
     $fn = utf8_decodeFN($fn);
-    $date = dformat($INFO['lastmod']);
+    $dateLocal = dformat($INFO['lastmod']);
+    $dateIso = date(DATE_ISO8601, $INFO['lastmod']);
 
     // print it
     if ($INFO['exists']) {
@@ -956,7 +957,7 @@ function tpl_pageinfo($ret = false)
         $out .= ' · ';
         $out .= $lang['lastmod'];
         $out .= ' ';
-        $out .= $date;
+        $out .= '<time datetime="' . $dateIso . '">' . $dateLocal . '</time>';
         if ($INFO['editor']) {
             $out .= ' ' . $lang['by'] . ' ';
             $out .= '<bdi>' . editorinfo($INFO['editor']) . '</bdi>';


### PR DESCRIPTION
This is a simple update to the "Last modified" field at the bottom of each article, which wraps the date in `<time>` elements, with an added `datetime` attribute (formatted as ISO-8601), as described in issue #4340.

Here is a screenshot of the page inspector code, as it is generated after this change (with a deliberately complex date format set in the config):
![image](https://github.com/user-attachments/assets/b4c0b0b0-77f6-4094-beef-cba88b870bca)

As the `<time>` element in _inline_, and does not have any formatting associated with it, this change should be transparent with regards to the visual appearance of the page.

Here is a screenshot of how it appears with the default template (= no change to the old design):
![image](https://github.com/user-attachments/assets/72195b32-5a25-4cf4-a7ac-bd0f3c61cf12)


Its added benefit is that the date becomes reliably machine-readable and can be reused for automation and scripting.