### PR TITLE
Code cleanup and Accessibility improvements for the Configuration Manager plugin

### DIFF
--- a/lib/plugins/config/admin.php
+++ b/lib/plugins/config/admin.php
@@ -77,24 +77,26 @@ class admin_plugin_config extends AdminPlugin
         $allow_debug = $GLOBALS['conf']['allowdebug']; // avoid global $conf; here.
         global $lang;
         global $ID;
+		
+		define('kHeadlineLevel', '2'); /* change this if doc structure requires */
 
         $this->setupLocale(true);
 
         echo $this->locale_xhtml('intro');
 
-        echo '<div id="config__manager">';
+        echo '<article id="config__manager">';
 
         if ($this->configuration->isLocked()) {
-            echo '<div class="info">' . $this->getLang('locked') . '</div>';
+            echo '<p class="highlight">' . $this->getLang('locked') . '</p>';
         }
 
         // POST to script() instead of wl($ID) so config manager still works if
         // rewrite config is broken. Add $ID as hidden field to remember
         // current ID in most cases.
         echo '<form id="dw__configform" action="' . script() . '" method="post">';
-        echo '<div class="no"><input type="hidden" name="id" value="' . $ID . '" /></div>';
+        echo '<div class="no"><input type="hidden" name="id" value="' . $ID . '"></div>';
         formSecurityToken();
-        $this->printH1('dokuwiki_settings', $this->getLang('_header_dokuwiki'));
+        $this->printHeadline(kHeadlineLevel, 'dokuwiki_settings', $this->getLang('_header_dokuwiki'));
 
         $in_fieldset = false;
         $first_plugin_fieldset = true;
@@ -105,53 +107,68 @@ class admin_plugin_config extends AdminPlugin
             } elseif ($setting instanceof SettingFieldset) {
                 // config setting group
                 if ($in_fieldset) {
-                    echo '</table>';
                     echo '</div>';
-                    echo '</fieldset>';
+                    echo '</section>';
                 } else {
                     $in_fieldset = true;
                 }
                 if ($first_plugin_fieldset && $setting->getType() == 'plugin') {
-                    $this->printH1('plugin_settings', $this->getLang('_header_plugin'));
+                    $this->printHeadline(kHeadlineLevel, 'plugin_settings', $this->getLang('_header_plugin'));
                     $first_plugin_fieldset = false;
                 } elseif ($first_template_fieldset && $setting->getType() == 'template') {
-                    $this->printH1('template_settings', $this->getLang('_header_template'));
+                    $this->printHeadline(kHeadlineLevel, 'template_settings', $this->getLang('_header_template'));
                     $first_template_fieldset = false;
                 }
-                echo '<fieldset id="' . $setting->getKey() . '">';
-                echo '<legend>' . $setting->prompt($this) . '</legend>';
-                echo '<div class="table">';
-                echo '<table class="inline">';
+                echo '<section id="' . $setting->getKey() . '">';
+                echo '<h3>' . $setting->prompt($this) . '</h3>';
+                echo '<div class="settings">';
+
             } else {
                 // config settings
                 [$label, $input] = $setting->html($this, $this->hasErrors);
 
-                $class = $setting->isDefault()
-                    ? ' class="default"'
-                    : ($setting->isProtected() ? ' class="protected"' : '');
-                $error = $setting->hasError()
-                    ? ' class="value error"'
-                    : ' class="value"';
-                $icon = $setting->caution()
-                    ? '<img src="' . self::IMGDIR . $setting->caution() . '.png" ' .
-                    'alt="' . $setting->caution() . '" title="' . $this->getLang($setting->caution()) . '" />'
-                    : '';
+                // build the classlist and status text:
+                $classlist = [];
+				$status = [];
+				array_push($status, ($setting->isDefault() ? 'default' : 'modified'));
+                if ($setting->isDefault()) array_push($classlist, 'default');
+                if ($setting->isProtected()) {
+					array_push($classlist, 'protected');
+					array_push($status, 'protected');
+				}
+                if ($setting->hasError()) {
+					array_push($classlist, 'error');
+					array_push($status, 'error');
+				}
+                if ($setting->caution()) array_push($classlist, 'caution');
 
-                echo '<tr' . $class . '>';
-                echo '<td class="label">';
-                echo '<span class="outkey">' . $setting->getPrettyKey() . '</span>';
-                echo $icon . $label;
-                echo '</td>';
-                echo '<td' . $error . '>' . $input . '</td>';
-                echo '</tr>';
+				$makeLi = function(string $it): string {
+					$txt = $this->getLang('a11y_stat_' . $it);
+					$status = $this->getLang('a11y_status');
+					return "<li class=\"$it\" title=\"$status $txt\"><span class=\"a11y\">$txt</span></li>";
+				};
+
+                // build the HTML code:
+                echo '<dl class="' . implode(' ', $classlist) . '">';
+                echo '<dt class="outkey">' . $setting->getPrettyKey() . '</dt>';
+                echo '<dd class="status"><span class="a11y">' . $this->getLang('a11y_status') . ' </span><ul>'
+				. implode(array_map($makeLi, $status)) . '</ul></dd>';
+                echo '<dd class="label">' . $label . '</dd>';
+                echo '<dd class="value">' . $input . '</dd>';
+                if ($setting->caution()) {
+                    echo '<dd class="' . $setting->caution() . '">' . $this->getLang($setting->caution()) . '</dd>';
+                }
+                echo '</dl>';
             }
         }
 
-        echo '</table>';
         echo '</div>';
-        if ($in_fieldset) {
-            echo '</fieldset>';
+        echo '</section>';
+        /* This does not seem to be needed any longer after the HTML changes
+                if ($in_fieldset) {
+            echo '</fieldset><!-- line 148 -->';
         }
+                */
 
         // show undefined settings list
         $undefined_settings = $this->configuration->getUndefined();
@@ -169,37 +186,33 @@ class admin_plugin_config extends AdminPlugin
             }
 
             usort($undefined_settings, 'settingNaturalComparison');
-            $this->printH1('undefined_settings', $this->getLang('_header_undefined'));
-            echo '<fieldset>';
-            echo '<div class="table">';
-            echo '<table class="inline">';
+            $this->printHeadline(kHeadlineLevel, 'undefined_settings', $this->getLang('_header_undefined'));
+            echo '<section>';
+            echo '<dl>';
             foreach ($undefined_settings as $setting) {
                 [$label, $input] = $setting->html($this);
-                echo '<tr>';
-                echo '<td class="label">' . $label . '</td>';
-                echo '<td>' . $input . '</td>';
+                echo '<dd class="label">' . $label . '</dd>';
+                echo '<dd class="value">' . $input . '</dd>';
                 echo '</tr>';
             }
-            echo '</table>';
-            echo '</div>';
-            echo '</fieldset>';
+            echo '</dl>';
+            echo '</section>';
         }
 
         // finish up form
-        echo '<p>';
-        echo '<input type="hidden" name="do"     value="admin" />';
-        echo '<input type="hidden" name="page"   value="config" />';
+        echo '<footer>';
+        echo '<input type="hidden" name="do" value="admin">';
+        echo '<input type="hidden" name="page" value="config">';
 
         if (!$this->configuration->isLocked()) {
-            echo '<input type="hidden" name="save"   value="1" />';
-            echo '<button type="submit" name="submit" accesskey="s">' . $lang['btn_save'] . '</button>';
-            echo '<button type="reset">' . $lang['btn_reset'] . '</button>';
+            echo '<input type="hidden" name="save" value="1">';
+			echo '<p><button type="submit" name="submit" accesskey="s">' . $lang['btn_save'] . '</button>';
+            echo '<button type="reset">' . $lang['btn_reset'] . '</button></p>';
         }
 
-        echo '</p>';
-
+        echo '</footer>';
         echo '</form>';
-        echo '</div>';
+        echo '</article>';
     }
 
     /**
@@ -268,12 +281,13 @@ class admin_plugin_config extends AdminPlugin
     }
 
     /**
-     * @param string $id
+     * @param int $level
+	 * @param string $id
      * @param string $text
      */
-    protected function printH1($id, $text)
+    protected function printHeadline($level, $id, $text)
     {
-        echo '<h1 id="' . $id . '">' . $text . '</h1>';
+        echo '<h' . $level . ' id="' . $id . '">' . $text . '</h2>';
     }
 
     /**

--- a/lib/plugins/config/core/Setting/SettingArray.php
+++ b/lib/plugins/config/core/Setting/SettingArray.php
@@ -81,7 +81,7 @@ class SettingArray extends Setting
 
         $label = '<label for="config___' . $key . '">' . $this->prompt($plugin) . '</label>';
         $input = '<input id="config___' . $key . '" name="config[' . $key .
-            ']" type="text" class="edit" value="' . $value . '" ' . $disable . '/>';
+            ']" type="text" class="edit" value="' . $value . '" ' . $disable . '>';
         return [$label, $input];
     }
 }

--- a/lib/plugins/config/core/Setting/SettingMulticheckbox.php
+++ b/lib/plugins/config/core/Setting/SettingMulticheckbox.php
@@ -54,7 +54,7 @@ class SettingMulticheckbox extends SettingString
         $value = $this->str2array($value);
         $default = $this->str2array($this->default);
 
-        $input = '';
+        $input = '<fieldset class="input">';
         foreach ($this->choices as $choice) {
             $idx = array_search($choice, $value);
             $idx_default = array_search($choice, $default);
@@ -99,6 +99,7 @@ class SettingMulticheckbox extends SettingString
                 $input .= "</div>\n";
             }
         }
+		$input .= '</fieldset>';
         $label = '<label>' . $this->prompt($plugin) . '</label>';
         return [$label, $input];
     }

--- a/lib/plugins/config/core/Setting/SettingMulticheckbox.php
+++ b/lib/plugins/config/core/Setting/SettingMulticheckbox.php
@@ -69,7 +69,7 @@ class SettingMulticheckbox extends SettingString
             $input .= '<div class="selection' . $class . '">' . "\n";
             $input .= '<label for="config___' . $key . '_' . $choice . '">' . $prompt . "</label>\n";
             $input .= '<input id="config___' . $key . '_' . $choice . '" name="config[' . $key .
-                '][]" type="checkbox" class="checkbox" value="' . $choice . '" ' . $disable . ' ' . $checked . "/>\n";
+                '][]" type="checkbox" class="checkbox" value="' . $choice . '" ' . $disable . ' ' . $checked . ">\n";
             $input .= "</div>\n";
 
             // remove this action from the disabledactions array

--- a/lib/plugins/config/core/Setting/SettingMultichoice.php
+++ b/lib/plugins/config/core/Setting/SettingMultichoice.php
@@ -49,6 +49,7 @@ class SettingMultichoice extends SettingString
 
             $choice = htmlspecialchars($choice);
             $option = htmlspecialchars($option);
+            if ($option == '') $option = '&nbsp;';
             $input .= '  <option value="' . $choice . '"' . $selected . ' >' . $option . '</option>' . "\n";
         }
         $input .= "</select> $nochoice \n";

--- a/lib/plugins/config/core/Setting/SettingOnoff.php
+++ b/lib/plugins/config/core/Setting/SettingOnoff.php
@@ -41,7 +41,7 @@ class SettingOnoff extends SettingNumeric
 
         $label = '<label for="config___' . $key . '">' . $this->prompt($plugin) . '</label>';
         $input = '<div class="input"><input id="config___' . $key . '" name="config[' . $key .
-            ']" type="checkbox" class="checkbox" value="1"' . $checked . $disable . '/></div>';
+            ']" type="checkbox" class="checkbox" value="1"' . $checked . $disable . '></div>';
         return [$label, $input];
     }
 

--- a/lib/plugins/config/core/Setting/SettingPassword.php
+++ b/lib/plugins/config/core/Setting/SettingPassword.php
@@ -35,7 +35,7 @@ class SettingPassword extends SettingString
 
         $label = '<label for="config___' . $key . '">' . $this->prompt($plugin) . '</label>';
         $input = '<input id="config___' . $key . '" name="config[' . $key .
-            ']" autocomplete="off" type="password" class="edit" value="" ' . $disable . ' />';
+            ']" autocomplete="off" type="password" class="edit" value="" ' . $disable . ' >';
         return [$label, $input];
     }
 }

--- a/lib/plugins/config/core/Setting/SettingString.php
+++ b/lib/plugins/config/core/Setting/SettingString.php
@@ -26,7 +26,7 @@ class SettingString extends Setting
 
         $label = '<label for="config___' . $key . '">' . $this->prompt($plugin) . '</label>';
         $input = '<input id="config___' . $key . '" name="config[' . $key .
-            ']" type="text" class="edit" value="' . $value . '" ' . $disable . '/>';
+            ']" type="text" class="edit" value="' . $value . '" ' . $disable . '>';
         return [$label, $input];
     }
 }

--- a/lib/plugins/config/lang/de-informal/lang.php
+++ b/lib/plugins/config/lang/de-informal/lang.php
@@ -216,3 +216,10 @@ $lang['useheading_o_navigation'] = 'Nur Navigation';
 $lang['useheading_o_content']  = 'Nur Wiki-Inhalt';
 $lang['useheading_o_1']        = 'Immer';
 $lang['readdircache']          = 'Maximales Alter des readdir-Caches (Sekunden)';
+
+/* Accessibility strings */
+$lang['a11y_status'] = 'Status:';
+$lang['a11y_stat_default'] = 'Voreingestellter Wert';
+$lang['a11y_stat_modified'] = 'Wert wurde verändert';
+$lang['a11y_stat_protected'] = 'Geschütztes Feld';
+$lang['a11y_stat_error'] = 'Dieses Feld enthält einen ungültigen Wert';

--- a/lib/plugins/config/lang/de/lang.php
+++ b/lib/plugins/config/lang/de/lang.php
@@ -234,3 +234,10 @@ $lang['useheading_o_navigation'] = 'Nur Navigation';
 $lang['useheading_o_content']  = 'Nur Wikiinhalt';
 $lang['useheading_o_1']        = 'Immer';
 $lang['readdircache']          = 'Maximales Alter des readdir-Caches (Sekunden)';
+
+/* Accessibility strings */
+$lang['a11y_status'] = 'Status:';
+$lang['a11y_stat_default'] = 'Voreingestellter Wert';
+$lang['a11y_stat_modified'] = 'Wert wurde verändert';
+$lang['a11y_stat_protected'] = 'Geschütztes Feld';
+$lang['a11y_stat_error'] = 'Dieses Feld enthält einen ungültigen Wert';

--- a/lib/plugins/config/lang/en/lang.php
+++ b/lib/plugins/config/lang/en/lang.php
@@ -278,3 +278,10 @@ $lang['useheading_o_content'] = 'Wiki Content Only';
 $lang['useheading_o_1'] = 'Always';
 
 $lang['readdircache'] = 'Maximum age for readdir cache (sec)';
+
+/* Accessibility strings */
+$lang['a11y_status'] = 'Status:';
+$lang['a11y_stat_default'] = 'Default value';
+$lang['a11y_stat_modified'] = 'Value has been modified';
+$lang['a11y_stat_protected'] = 'Protected field';
+$lang['a11y_stat_error'] = 'This field contains an invalid value';

--- a/lib/plugins/config/lang/fi/lang.php
+++ b/lib/plugins/config/lang/fi/lang.php
@@ -189,3 +189,10 @@ $lang['useheading_o_navigation'] = 'Vain Navigointi';
 $lang['useheading_o_content']  = 'Vain Wiki-sisältö';
 $lang['useheading_o_1']        = 'Aina';
 $lang['readdircache']          = 'Maksimiaika readdir cachelle (sek)';
+
+/* Accessibility strings */
+$lang['a11y_status'] = 'Tilanne:';
+$lang['a11y_stat_default'] = 'Oletusarvo';
+$lang['a11y_stat_modified'] = 'Arvoa on muutettu';
+$lang['a11y_stat_protected'] = 'Suojattu kenttä';
+$lang['a11y_stat_error'] = 'Tämä kenttä sisältää virheellisen arvon';

--- a/lib/plugins/config/lang/fr/lang.php
+++ b/lib/plugins/config/lang/fr/lang.php
@@ -238,3 +238,10 @@ $lang['useheading_o_navigation'] = 'Navigation seulement';
 $lang['useheading_o_content']  = 'Contenu du wiki seulement';
 $lang['useheading_o_1']        = 'Toujours';
 $lang['readdircache']          = 'Durée de vie maximale du cache pour readdir (sec)';
+
+/* Accessibility strings */
+$lang['a11y_status'] = 'Statut :';
+$lang['a11y_stat_default'] = 'Valeur par défaut';
+$lang['a11y_stat_modified'] = 'Valeur modifiée';
+$lang['a11y_stat_protected'] = 'Champ protégé';
+$lang['a11y_stat_error'] = 'Ce champ contient une valeur invalide';

--- a/lib/plugins/config/style.css
+++ b/lib/plugins/config/style.css
@@ -13,16 +13,16 @@
   color: __text__;
 }
 
-#config__manager fieldset {
-  margin: 1em;
-  width: auto;
-  margin-bottom: 2em;
-  padding: 0 1em;
+/* headlines */
+#config__manager h3 {
+	font-size: 1.75em;
+}
+#config__manager h3 {
+	font-size: 1.5em;
+	margin: 1em 0;
 }
 
-#config__manager section {
-}
-
+/* list */
 #config__manager dl {
   background-color: __background__;
   border: __border__ solid 1px;;
@@ -31,20 +31,18 @@
   grid-template-columns: 1fr 2fr;
   line-height: 1.5em;
 }
-#config__manager dl.error {
-}
-
 #config__manager dl dt {
   font-size: smaller;
   padding: .25em;
 }
-
 #config__manager dl dd {
   margin: 0;
   padding: .25em;
 }
+
+/* status field */
 #config__manager dl dd.status {
-		text-align: right;
+  text-align: right;
 }
 #config__manager dl dd.status ul {
 	list-style: none inside;
@@ -60,7 +58,6 @@
 #config__manager dl dd.status ul li:last-child::after {
 	content: '';
 }
-
 #config__manager dl dd.status ul li::before {
 	content: '';
 	display: inline-block;
@@ -69,28 +66,54 @@
 	background-size: 1em;
 }
 #config__manager dl dd.status ul li.default::before {
-	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z' style='fill:%23789'/%3E%3C/svg%3E");
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z' style='fill:%232b73b7'/%3E%3C/svg%3E");
 }
 #config__manager dl dd.status ul li.modified::before {
-	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12,2C6.47,2 2,6.47 2,12C2,17.53 6.47,22 12,22C17.53,22 22,17.53 22,12C22,6.47 17.53,2 12,2M15.1,7.07C15.24,7.07 15.38,7.12 15.5,7.23L16.77,8.5C17,8.72 17,9.07 16.77,9.28L15.77,10.28L13.72,8.23L14.72,7.23C14.82,7.12 14.96,7.07 15.1,7.07M13.13,8.81L15.19,10.87L9.13,16.93H7.07V14.87L13.13,8.81Z' style='fill:%232b73b7'/%3E%3C/svg%3E");
-}#config__manager dl dd.status ul li.protected::before {
-	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12,17A2,2 0 0,0 14,15C14,13.89 13.1,13 12,13A2,2 0 0,0 10,15A2,2 0 0,0 12,17M18,8A2,2 0 0,1 20,10V20A2,2 0 0,1 18,22H6A2,2 0 0,1 4,20V10C4,8.89 4.9,8 6,8H7V6A5,5 0 0,1 12,1A5,5 0 0,1 17,6V8H18M12,3A3,3 0 0,0 9,6V8H15V6A3,3 0 0,0 12,3Z' style='fill:%23D99D36'/%3E%3C/svg%3E");
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M5,3C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19H5V5H12V3H5M17.78,4C17.61,4 17.43,4.07 17.3,4.2L16.08,5.41L18.58,7.91L19.8,6.7C20.06,6.44 20.06,6 19.8,5.75L18.25,4.2C18.12,4.07 17.95,4 17.78,4M15.37,6.12L8,13.5V16H10.5L17.87,8.62L15.37,6.12Z' style='fill:%23789' /%3E%3C/svg%3E");
+}
+#config__manager dl dd.status ul li.protected::before {
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 2C17.5 2 22 6.5 22 12S17.5 22 12 22 2 17.5 2 12 6.5 2 12 2M12 4C10.1 4 8.4 4.6 7.1 5.7L18.3 16.9C19.3 15.5 20 13.8 20 12C20 7.6 16.4 4 12 4M16.9 18.3L5.7 7.1C4.6 8.4 4 10.1 4 12C4 16.4 7.6 20 12 20C13.9 20 15.6 19.4 16.9 18.3Z' style='fill:%23C2462C'/%3E%3C/svg%3E ");
 }
 #config__manager dl dd.status ul li.error::before {
 	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M19,3H16.3H7.7H5A2,2 0 0,0 3,5V7.7V16.4V19A2,2 0 0,0 5,21H7.7H16.4H19A2,2 0 0,0 21,19V16.3V7.7V5A2,2 0 0,0 19,3M15.6,17L12,13.4L8.4,17L7,15.6L10.6,12L7,8.4L8.4,7L12,10.6L15.6,7L17,8.4L13.4,12L17,15.6L15.6,17Z' style='fill:%23C2462C'/%3E%3C/svg%3E");
 }
+[dir=rtl] #config__manager dl dd.status {
+  text-align: left;
+}
 
-
+/* value field */
+#config__manager dl dd.value {
+}
+#config__manager dl dd.value div.input {
+	width: fit-content;
+	padding: 0 .25em;
+}
+#config__manager dl dd.value input,
+#config__manager dl dd.value select {
+	width: max-content;
+	max-width: 100%;
+}
+#config__manager dl dd.value fieldset {
+	border: transparent none 0;
+	margin: 0; padding: 0;
+	width: 100%;
+}
+#config__manager dl dd.value fieldset label {
+	text-align: left;
+}
 #config__manager dl.caution dd.label {
 	grid-row: 2 / span 2;
 }
 
+/* warning field */
 #config__manager dl dd.warning,
 #config__manager dl dd.danger,
 #config__manager dl dd.security {
-	padding-left: 1.5em;
+	padding: 0 0 0 1.5em;
 	background: transparent none 0 .35em no-repeat;
 	background-size: 1.2em;
+	font-size: smaller;
+	grid-column: 2;
 }
 #config__manager dl dd.warning {
 	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M13 14H11V9H13M13 18H11V16H13M1 21H23L12 2L1 21Z' style='fill:%23D69320' /%3E%3C/svg%3E");
@@ -99,6 +122,12 @@
 	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M13,13H11V7H13M13,17H11V15H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z' style='fill:%23C2462C' /%3E%3C/svg%3E");
 }#config__manager dl dd.security {
 	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12,17C10.89,17 10,16.1 10,15C10,13.89 10.89,13 12,13A2,2 0 0,1 14,15A2,2 0 0,1 12,17M18,20V10H6V20H18M18,8A2,2 0 0,1 20,10V20A2,2 0 0,1 18,22H6C4.89,22 4,21.1 4,20V10C4,8.89 4.89,8 6,8H7V6A5,5 0 0,1 12,1A5,5 0 0,1 17,6V8H18M12,3A3,3 0 0,0 9,6V8H15V6A3,3 0 0,0 12,3Z' style='fill:%23D99D36' /%3E%3C/svg%3E");
+}
+[dir=rtl] #config__manager dl dd.warning,
+[dir=rtl] #config__manager dl dd.danger,
+[dir=rtl] #config__manager dl dd.security {
+	padding: 0 1.5em 0 0;
+	background-position: right .25em;
 }
 
 #config__manager .selection {
@@ -128,6 +157,16 @@
   font-size: 90%;
 }
 
+/* blue background of items with default values */
+#config__manager dl.default .input,
+#config__manager dl.default input,
+#config__manager dl.default textarea,
+#config__manager dl.default select,
+#config__manager .selectiondefault {
+	background-color: #cdf;
+	color: #000;
+}
+
 /* change layout in mobile view: */
 @media (max-width: @ini_phone_width) {
 	#config__manager dl dd {
@@ -137,6 +176,17 @@
 	#config__manager dl dd.status {
 		grid-column: 2;
 	}
+	#config__manager dl dd.warning,
+	#config__manager dl dd.danger,
+	#config__manager dl dd.security {
+		grid-column: 1 / span 2;
+	}
+	[dir=rtl] #config__manager dl dd.warning,
+	[dir=rtl] #config__manager dl dd.danger,
+	[dir=rtl] #config__manager dl dd.security {
+		background-position: right .25em;
+	}
+
 }
 
 /* end plugin:configmanager */

--- a/lib/plugins/config/style.css
+++ b/lib/plugins/config/style.css
@@ -1,140 +1,105 @@
 /* plugin:configmanager */
-#config__manager div.success,
-#config__manager div.error,
-#config__manager div.info {
+#config__manager p.highlight {
+  background-color: #ccf;
+  background-image: url(../images/info.png);
+  border-color: #ccf;
   background-position: 0.5em;
-  padding: 0.5em;
-  text-align: center;
+  padding: 0.5em .5em .5em 32px;
+  /*text-align: center;*/
+}
+
+#config__manager {
+  clear: both;
+  color: __text__;
 }
 
 #config__manager fieldset {
   margin: 1em;
   width: auto;
   margin-bottom: 2em;
-  background-color: __background_alt__;
-  color: __text__;
   padding: 0 1em;
 }
-[dir=rtl] #config__manager fieldset {
-    clear: both;
-}
-#config__manager legend {
-    font-size: 1.25em;
+
+#config__manager section {
 }
 
-#config__manager form { }
-#config__manager table {
-    margin: 1em 0;
-    width: 100%;
+#config__manager dl {
+  background-color: __background__;
+  border: __border__ solid 1px;;
+  margin: .25rem 0;
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  line-height: 1.5em;
+}
+#config__manager dl.error {
 }
 
-#config__manager fieldset td {
-    text-align: left;
-}
-[dir=rtl] #config__manager fieldset td {
-    text-align: right;
-}
-#config__manager fieldset td.value {
-    /* fixed data column width */
-    width: 31em;
+#config__manager dl dt {
+  font-size: smaller;
+  padding: .25em;
 }
 
-[dir=rtl] #config__manager label {
-    text-align: right;
+#config__manager dl dd {
+  margin: 0;
+  padding: .25em;
 }
-[dir=rtl] #config__manager td.value input.checkbox {
-    float: right;
-    padding-left: 0;
-    padding-right: 0.7em;
+#config__manager dl dd.status {
+		text-align: right;
 }
-[dir=rtl] #config__manager td.value label {
-    float: left;
+#config__manager dl dd.status ul {
+	list-style: none inside;
+	display: inline-block;
 }
-
-#config__manager td.label {
-    padding: 0.8em 0 0.6em 1em;
-    vertical-align: top;
+#config__manager dl dd.status ul li {
+	display: inline;
+	margin: 0; padding: 0;
 }
-[dir=rtl] #config__manager td.label {
-    padding: 0.8em 1em 0.6em 0;
+#config__manager dl dd.status ul li::after {
+	content: ',';
 }
-
-#config__manager td.label label {
-    clear: left;
-    display: block;
-}
-[dir=rtl] #config__manager td.label label {
-    clear: right;
-}
-#config__manager td.label img {
-    padding: 0 10px;
-    vertical-align: middle;
-    float: right;
-}
-[dir=rtl] #config__manager td.label img {
-    float: left;
+#config__manager dl dd.status ul li:last-child::after {
+	content: '';
 }
 
-#config__manager td.label span.outkey {
-    font-size: 70%;
-    margin-top: -1.7em;
-    margin-left: -1em;
-    display: block;
-    background-color: __background__;
-    color: __text_neu__;
-    float: left;
-    padding: 0 0.1em;
-    position: relative;
-    z-index: 1;
+#config__manager dl dd.status ul li::before {
+	content: '';
+	display: inline-block;
+	width: 1em; height: 1em;
+	background: transparent url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ctitle%3Ehelp-circle-outline%3C/title%3E%3Cpath d='M11,18H13V16H11V18M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,6A4,4 0 0,0 8,10H10A2,2 0 0,1 12,8A2,2 0 0,1 14,10C14,12 11,11.75 11,15H13C13,12.75 16,12.5 16,10A4,4 0 0,0 12,6Z' style='fill:%23CCC'/%3E%3C/svg%3E") center no-repeat;
+	background-size: 1em;
 }
-[dir=rtl] #config__manager td.label span.outkey {
-    float: right;
-    margin-right: 1em;
+#config__manager dl dd.status ul li.default::before {
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z' style='fill:%23789'/%3E%3C/svg%3E");
 }
-
-#config__manager td input.edit {
-    width: 30em;
+#config__manager dl dd.status ul li.modified::before {
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12,2C6.47,2 2,6.47 2,12C2,17.53 6.47,22 12,22C17.53,22 22,17.53 22,12C22,6.47 17.53,2 12,2M15.1,7.07C15.24,7.07 15.38,7.12 15.5,7.23L16.77,8.5C17,8.72 17,9.07 16.77,9.28L15.77,10.28L13.72,8.23L14.72,7.23C14.82,7.12 14.96,7.07 15.1,7.07M13.13,8.81L15.19,10.87L9.13,16.93H7.07V14.87L13.13,8.81Z' style='fill:%232b73b7'/%3E%3C/svg%3E");
+}#config__manager dl dd.status ul li.protected::before {
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12,17A2,2 0 0,0 14,15C14,13.89 13.1,13 12,13A2,2 0 0,0 10,15A2,2 0 0,0 12,17M18,8A2,2 0 0,1 20,10V20A2,2 0 0,1 18,22H6A2,2 0 0,1 4,20V10C4,8.89 4.9,8 6,8H7V6A5,5 0 0,1 12,1A5,5 0 0,1 17,6V8H18M12,3A3,3 0 0,0 9,6V8H15V6A3,3 0 0,0 12,3Z' style='fill:%23D99D36'/%3E%3C/svg%3E");
 }
-#config__manager td .input {
-    width: 30.8em;
-}
-#config__manager td select.edit { }
-#config__manager td textarea.edit {
-    width: 27.5em;
-    height: 4em;
+#config__manager dl dd.status ul li.error::before {
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M19,3H16.3H7.7H5A2,2 0 0,0 3,5V7.7V16.4V19A2,2 0 0,0 5,21H7.7H16.4H19A2,2 0 0,0 21,19V16.3V7.7V5A2,2 0 0,0 19,3M15.6,17L12,13.4L8.4,17L7,15.6L10.6,12L7,8.4L8.4,7L12,10.6L15.6,7L17,8.4L13.4,12L17,15.6L15.6,17Z' style='fill:%23C2462C'/%3E%3C/svg%3E");
 }
 
-#config__manager td textarea.edit:focus {
-    height: 10em;
+
+#config__manager dl.caution dd.label {
+	grid-row: 2 / span 2;
 }
 
-#config__manager tr .input,
-#config__manager tr input,
-#config__manager tr textarea,
-#config__manager tr select {
-  background-color: #fff;
-  color: #000;
+#config__manager dl dd.warning,
+#config__manager dl dd.danger,
+#config__manager dl dd.security {
+	padding-left: 1.5em;
+	background: transparent none 0 .35em no-repeat;
+	background-size: 1.2em;
 }
-
-#config__manager tr.default .input,
-#config__manager tr.default input,
-#config__manager tr.default textarea,
-#config__manager tr.default select,
-#config__manager .selectiondefault {
-  background-color: #ccddff;
-  color: #000;
+#config__manager dl dd.warning {
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M13 14H11V9H13M13 18H11V16H13M1 21H23L12 2L1 21Z' style='fill:%23D69320' /%3E%3C/svg%3E");
 }
-
-#config__manager tr.protected .input,
-#config__manager tr.protected input,
-#config__manager tr.protected textarea,
-#config__manager tr.protected select,
-#config__manager tr.protected .selection {
-  background-color: #ffcccc!important;
-  color: #000 !important;
+#config__manager dl dd.danger {
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M13,13H11V7H13M13,17H11V15H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z' style='fill:%23C2462C' /%3E%3C/svg%3E");
+}#config__manager dl dd.security {
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12,17C10.89,17 10,16.1 10,15C10,13.89 10.89,13 12,13A2,2 0 0,1 14,15A2,2 0 0,1 12,17M18,20V10H6V20H18M18,8A2,2 0 0,1 20,10V20A2,2 0 0,1 18,22H6C4.89,22 4,21.1 4,20V10C4,8.89 4.89,8 6,8H7V6A5,5 0 0,1 12,1A5,5 0 0,1 17,6V8H18M12,3A3,3 0 0,0 9,6V8H15V6A3,3 0 0,0 12,3Z' style='fill:%23D99D36' /%3E%3C/svg%3E");
 }
-
-#config__manager td.error  { background-color: red; color: #000; }
 
 #config__manager .selection {
   width: 14.8em;
@@ -153,7 +118,6 @@
   font-size: 90%;
 }
 
-
 #config__manager .other {
   clear: both;
   padding-top: 0.5em;
@@ -162,6 +126,17 @@
 #config__manager .other label {
   padding-left: 2px;
   font-size: 90%;
+}
+
+/* change layout in mobile view: */
+@media (max-width: @ini_phone_width) {
+	#config__manager dl dd {
+		grid-column: 1 / span 2;
+		margin-left: .67em;
+	}
+	#config__manager dl dd.status {
+		grid-column: 2;
+	}
 }
 
 /* end plugin:configmanager */

--- a/lib/styles/screen.css
+++ b/lib/styles/screen.css
@@ -87,6 +87,8 @@ div.notify {
     width: 1px !important;
     height: 1px !important;
     overflow: hidden !important;
+    color: #000 !important;
+    background-color: #FFF !important;
 }
 [dir=rtl] .a11y {
     left: auto !important;


### PR DESCRIPTION
This is a collection of improvements for the items mentioned in issue #4342.

Replaced the table layouts with DL structures. These are more flexible to lay out and have some Accessibility improvements as well.

This also enables a more useful layout for mobile view. Tested down to ca. 320px screen width!

Several improvements to the semantic structure of the configuration page, including a more suitable headline structure.

In addition to the blue backgrounds for default values, there is now an icon shown that shows the status. Additional icons can be displayed: locked items and if there is an error in the value. All icons are fully accessible with localized text that can be read out, or shown as title.

Warning icons are now shown as text (with the icon to the side). 

Localized strings for these texts in EN, DE, FR and FI.

A complete rewrite of the CSS for this plugin to make use of the changed code.