### PR TITLE
Fix PHP error while saving Aichat settings

### DIFF
--- a/lib/plugins/config/core/Loader.php
+++ b/lib/plugins/config/core/Loader.php
@@ -213,7 +213,7 @@ class Loader
         $data = [];
         $data[$prefix . $type . '_settings_name'] = ['fieldset'];
         foreach ($meta as $key => $value) {
-            if ($value[0] == 'fieldset') continue; //plugins only get one fieldset
+            if (isset($value[0]) && $value[0] == 'fieldset') continue; //plugins only get one fieldset
             $data[$prefix . $key] = $value;
         }
 


### PR DESCRIPTION
When saving the Groq keys on aichat plugin, a PHP error is thrown on DokuWiki core plugin.