### PR TITLE
Fix loading of plugin language files

### DIFF
--- a/inc/Extension/PluginTrait.php
+++ b/inc/Extension/PluginTrait.php
@@ -136,8 +136,14 @@ trait PluginTrait
         if (!file_exists($file)) {
             $file = DOKU_PLUGIN . $plugin . '/lang/' . $conf['lang'] . '/' . $id . '.' . $ext;
             if (!file_exists($file)) {
-                //fall back to english
-                $file = DOKU_PLUGIN . $plugin . '/lang/en/' . $id . '.' . $ext;
+                $file = DOKU_CONF . 'plugin_lang/' . $plugin . '/' . sexplode("-", $conf['lang'], 2)[0] . '/' . $id . '.' . $ext; // pt-br = pt
+                if (!file_exists($file)) {
+                    $file = DOKU_PLUGIN . $plugin . '/lang/' . sexplode("-", $conf['lang'], 2)[0] . '/' . $id . '.' . $ext; // pt-br = pt
+                    if (!file_exists($file)) {
+                        //fall back to english
+                        $file = DOKU_PLUGIN . $plugin . '/lang/en/' . $id . '.' . $ext;
+                    }
+                }
             }
         }
         return $file;
@@ -168,6 +174,8 @@ trait PluginTrait
             foreach ($config_cascade['lang']['plugin'] as $config_file) {
                 if (file_exists($config_file . $this->getPluginName() . '/' . $conf['lang'] . '/lang.php')) {
                     include($config_file . $this->getPluginName() . '/' . $conf['lang'] . '/lang.php');
+                } elseif (file_exists($config_file . $this->getPluginName() . '/' . sexplode("-", $conf['lang'], 2)[0] . '/lang.php')) {
+                    include($config_file . $this->getPluginName() . '/' . sexplode("-", $conf['lang'], 2)[0] . '/lang.php'); // pt-br = pt
                 }
             }
         }

--- a/inc/template.php
+++ b/inc/template.php
@@ -1355,6 +1355,8 @@ function tpl_getLang($id)
             foreach ($config_cascade['lang']['template'] as $config_file) {
                 if (file_exists($config_file . $conf['template'] . '/' . $conf['lang'] . '/lang.php')) {
                     include($config_file . $conf['template'] . '/' . $conf['lang'] . '/lang.php');
+                } elseif (file_exists($config_file . $conf['template'] . '/' . sexplode("-", $conf['lang'], 2)[0] . '/lang.php')) {
+                    include($config_file . $conf['template'] . '/' . sexplode("-", $conf['lang'], 2)[0] . '/lang.php'); // pt-br = pt
                 }
             }
         }
@@ -1388,8 +1390,14 @@ function tpl_localeFN($id)
     if (!file_exists($file)) {
         $file = $path . $conf['lang'] . '/' . $id . '.txt';
         if (!file_exists($file)) {
-            //fall back to english
-            $file = $path . 'en/' . $id . '.txt';
+            $file = DOKU_CONF . 'template_lang/' . $conf['template'] . '/' . sexplode("-", $conf['lang'], 2)[0] . '/' . $id . '.txt'; // pt-br = pt
+            if (!file_exists($file)) {
+                $file = $path . sexplode("-", $conf['lang'], 2)[0] . '/' . $id . '.txt'; // pt-br = pt
+                if (!file_exists($file)) {
+                    //fall back to english
+                    $file = $path . 'en/' . $id . '.txt';
+                }
+            }
         }
     }
     return $file;

--- a/lib/exe/js.php
+++ b/lib/exe/js.php
@@ -262,6 +262,9 @@ function js_pluginstrings()
                 if (file_exists($config_file . $p . '/' . $conf['lang'] . '/lang.php')) {
                     include($config_file . $p . '/' . $conf['lang'] . '/lang.php');
                 }
+                elseif (file_exists($config_file . $p . '/' . sexplode("-", $conf['lang'], 2)[0] . '/lang.php')) { // pt-br = pt
+                    include($config_file . $p . '/' . sexplode("-", $conf['lang'], 2)[0] . '/lang.php');
+                }
             }
         }
 

--- a/lib/exe/js.php
+++ b/lib/exe/js.php
@@ -255,15 +255,15 @@ function js_pluginstrings()
             if (file_exists($path . $conf['lang'] . "/lang.php")) {
                 include($path . $conf['lang'] . '/lang.php');
             }
-            elseif (file_exists($path . sexplode("-", $conf['lang'], 2)[0] . "/lang.php")) { // pt-br = pt
+            elseif (file_exists($path . sexplode("-", $conf['lang'], 2)[0] . "/lang.php")) {
                 include($path . sexplode("-", $conf['lang'], 2)[0] . '/lang.php');
             }
             foreach ($config_cascade['lang']['plugin'] as $config_file) {
                 if (file_exists($config_file . $p . '/' . $conf['lang'] . '/lang.php')) {
                     include($config_file . $p . '/' . $conf['lang'] . '/lang.php');
                 }
-                elseif (file_exists($config_file . $p . '/' . sexplode("-", $conf['lang'], 2)[0] . '/lang.php')) { // pt-br = pt
-                    include($config_file . $p . '/' . sexplode("-", $conf['lang'], 2)[0] . '/lang.php');
+                elseif (file_exists($config_file . $p . '/' . sexplode("-", $conf['lang'], 2)[0] . '/lang.php')) {
+                    include($config_file . $p . '/' . sexplode("-", $conf['lang'], 2)[0] . '/lang.php'); // pt-br = pt
                 }
             }
         }

--- a/lib/exe/js.php
+++ b/lib/exe/js.php
@@ -255,6 +255,9 @@ function js_pluginstrings()
             if (file_exists($path . $conf['lang'] . "/lang.php")) {
                 include($path . $conf['lang'] . '/lang.php');
             }
+            elseif (file_exists($path . sexplode("-", $conf['lang'], 2)[0] . "/lang.php")) { // pt-br = pt
+                include($path . sexplode("-", $conf['lang'], 2)[0] . '/lang.php');
+            }
             foreach ($config_cascade['lang']['plugin'] as $config_file) {
                 if (file_exists($config_file . $p . '/' . $conf['lang'] . '/lang.php')) {
                     include($config_file . $p . '/' . $conf['lang'] . '/lang.php');


### PR DESCRIPTION
Hello,
After my translation contribution to aichat plugin (https://github.com/cosmocode/dokuwiki-plugin-aichat/pull/21), it seems that the DokuWiki translator added it to 'pt' directory instead of 'pt-br', which isn't a big problem as it would allow 'pt-pt' and other lusophone languages uses the same translation as they are pretty similar, but my Wiki is set to 'pt-br' language and I noticed that the translation strings wasn't being loaded ('Your question' was being shown when opening the AIchat instead of the translated one). Then I started digging around and noticed that the ``js_pluginstrings`` seems to load only the folder which matches exactly the current DokuWiki language and falling back to 'en' when unable to find the 'lang.php' relative to the DokuWiki language. This commit make sures that if DokuWiki doesn't find the 'pt-br' on 'lang' subfolder of the plug-in, it will attempt to look back to 'pt' before falling back to 'en'.