### PR TITLE
Fix "No subnamespace" (Remote API)

### DIFF
--- a/inc/Remote/ApiCore.php
+++ b/inc/Remote/ApiCore.php
@@ -256,7 +256,7 @@ class ApiCore
         }
 
         // search_allpages handles depth weird, we need to add the given namespace depth
-        if ($depth && namespace != '') {
+        if ($depth && !empty(namespace)) {
             $depth += substr_count($namespace, ':') + 1;
         }
 

--- a/inc/Remote/ApiCore.php
+++ b/inc/Remote/ApiCore.php
@@ -256,7 +256,7 @@ class ApiCore
         }
 
         // search_allpages handles depth weird, we need to add the given namespace depth
-        if ($depth) {
+        if ($depth && namespace !== '') {
             $depth += substr_count($namespace, ':') + 1;
         }
 

--- a/inc/Remote/ApiCore.php
+++ b/inc/Remote/ApiCore.php
@@ -256,7 +256,7 @@ class ApiCore
         }
 
         // search_allpages handles depth weird, we need to add the given namespace depth
-        if ($depth && namespace !== '') {
+        if ($depth && namespace != '') {
             $depth += substr_count($namespace, ':') + 1;
         }
 

--- a/inc/Remote/ApiCore.php
+++ b/inc/Remote/ApiCore.php
@@ -256,7 +256,7 @@ class ApiCore
         }
 
         // search_allpages handles depth weird, we need to add the given namespace depth
-        if ($depth && $namespace !== '')) {
+        if ($depth && $namespace !== '') {
             $depth += substr_count($namespace, ':') + 1;
         }
 

--- a/inc/Remote/ApiCore.php
+++ b/inc/Remote/ApiCore.php
@@ -256,7 +256,7 @@ class ApiCore
         }
 
         // search_allpages handles depth weird, we need to add the given namespace depth
-        if ($depth && !empty(namespace)) {
+        if ($depth && $namespace !== '')) {
             $depth += substr_count($namespace, ':') + 1;
         }
 


### PR DESCRIPTION
The old API (https://github.com/dokuwiki/dokuwiki/blob/4396d6ec3e32bf7b711573ea7beb7bc7ba47dda5/inc/Remote/ApiCore.php#L313) doesn't seems to increase depth. When using "depth=1" (No subnamespace) with no namespace set, the DW sync plugin was retorning subnamespaces for remote Wiki (e.g. "3cx:extensions") while the local Wiki was returning only root namespaces (e.g. "3cx") as expected.