### PR TITLE
replace deprecated utf8_encode #4354

### DIFF
--- a/inc/common.php
+++ b/inc/common.php
@@ -1014,7 +1014,7 @@ function cleanText($text)
     // if the text is not valid UTF-8 we simply assume latin1
     // this won't break any worse than it breaks with the wrong encoding
     // but might actually fix the problem in many cases
-    if (!Clean::isUtf8($text)) $text = utf8_encode($text);
+    if (!Clean::isUtf8($text)) $text = Conversion::fromLatin1($text);
 
     return $text;
 }

--- a/lib/plugins/usermanager/admin.php
+++ b/lib/plugins/usermanager/admin.php
@@ -3,6 +3,7 @@
 use dokuwiki\Extension\AdminPlugin;
 use dokuwiki\Extension\AuthPlugin;
 use dokuwiki\Utf8\Clean;
+use dokuwiki\Utf8\Conversion;
 
 /*
  *  User Manager
@@ -1078,7 +1079,7 @@ class admin_plugin_usermanager extends AdminPlugin
         if ($fd) {
             while ($csv = fgets($fd)) {
                 if (!Clean::isUtf8($csv)) {
-                    $csv = utf8_encode($csv);
+                    $csv = Conversion::fromLatin1($csv);
                 }
                 $raw = str_getcsv($csv);
                 $error = '';                        // clean out any errors from the previous line


### PR DESCRIPTION
This uses any of the available alternatives before falling back to a native implementation