### PR TITLE
Remove check for deprecated E_STRICT

### DIFF
--- a/inc/init.php
+++ b/inc/init.php
@@ -44,7 +44,7 @@ if (!defined('DOKU_E_LEVEL') && file_exists(DOKU_CONF . 'report_e_all')) {
     define('DOKU_E_LEVEL', E_ALL);
 }
 if (!defined('DOKU_E_LEVEL')) {
-    error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
+    error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);
 } else {
     error_reporting(DOKU_E_LEVEL);
 }


### PR DESCRIPTION
The check for E_STRICT causes error for dokuwiki running on php:apache docker container which currently has Apache/2.4.62 and PHP 8.4.1.
As far as I can tell the check for E_STRICT shouldn't be needed for PHP version >=7.4.
The following error would appear when accessing the root of the site, and would be present at the top of all pages if /doku.php was accessed directly.

```
Deprecated: Constant E_STRICT is deprecated in /var/www/html/inc/init.php on line 47
Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/inc/init.php:47) in /var/www/html/inc/init.php on line 53
Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/inc/init.php:47) in /var/www/html/inc/auth.php on line 511
Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/inc/init.php:47) in /var/www/html/inc/common.php on line 1871
```