### PR TITLE
Preventing auto-filling of passwords in config #4362

### DIFF
--- a/lib/plugins/config/admin.php
+++ b/lib/plugins/config/admin.php
@@ -91,7 +91,7 @@ class admin_plugin_config extends AdminPlugin
         // POST to script() instead of wl($ID) so config manager still works if
         // rewrite config is broken. Add $ID as hidden field to remember
         // current ID in most cases.
-        echo '<form id="dw__configform" action="' . script() . '" method="post">';
+        echo '<form id="dw__configform" action="' . script() . '" method="post" autocomplete="off">';
         echo '<div class="no"><input type="hidden" name="id" value="' . $ID . '" /></div>';
         formSecurityToken();
         $this->printH1('dokuwiki_settings', $this->getLang('_header_dokuwiki'));

--- a/lib/plugins/config/core/Setting/SettingPassword.php
+++ b/lib/plugins/config/core/Setting/SettingPassword.php
@@ -35,7 +35,7 @@ class SettingPassword extends SettingString
 
         $label = '<label for="config___' . $key . '">' . $this->prompt($plugin) . '</label>';
         $input = '<input id="config___' . $key . '" name="config[' . $key .
-            ']" autocomplete="off" type="password" class="edit" value="" ' . $disable . ' />';
+            ']" autocomplete="new-password" type="password" class="edit" value="" ' . $disable . ' />';
         return [$label, $input];
     }
 }


### PR DESCRIPTION
We previously had set autocomplete="off" on password fields, but browsers seem to ignore that now.

MDN suggests [1] to use autocomplete="new-password", so that's what's used now. In addition autocomplete="off" is set on the form as a whole.

Will that fix the issue once and for all? Doubtful:

> This attribute is a hint to browsers; some may not comply with it.

[1] https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/Turning_off_form_autocompletion