### PR TITLE
fix revisions used in RSS feeds. fixes #4357

### DIFF
--- a/inc/Feed/FeedMediaProcessor.php
+++ b/inc/Feed/FeedMediaProcessor.php
@@ -139,7 +139,7 @@ class FeedMediaProcessor extends FeedItemProcessor
     protected function loadRevisions()
     {
         $changelog = new MediaChangeLog($this->id);
-        $revs = $changelog->getRevisions(0, 2);  // FIXME check that this returns the current one correctly
+        $revs = $changelog->getRevisions(-1, 2);
         if (!isset($this->data['rev'])) {
             // prefer an already set date, only set if missing
             // it should usally not happen that neither is available

--- a/inc/Feed/FeedPageProcessor.php
+++ b/inc/Feed/FeedPageProcessor.php
@@ -185,7 +185,7 @@ class FeedPageProcessor extends FeedItemProcessor
     protected function loadRevisions()
     {
         $changelog = new PageChangeLog($this->id);
-        $revs = $changelog->getRevisions(0, 2); // FIXME check that this returns the current one correctly
+        $revs = $changelog->getRevisions(-1, 2);
         if (!isset($this->data['rev'])) {
             // prefer an already set date, only set if missing
             // it should usally not happen that neither is available


### PR DESCRIPTION
A negative value needs to be passed to retrieve the current revision.