### PR TITLE
unset empty REMOTE_USER. fixes #4348

### DIFF
--- a/inc/auth.php
+++ b/inc/auth.php
@@ -47,6 +47,11 @@ function auth_setup()
     global $plugin_controller;
     $AUTH_ACL = [];
 
+    // unset REMOTE_USER if empty
+    if ($INPUT->server->str('REMOTE_USER') === '') {
+        $INPUT->server->remove('REMOTE_USER');
+    }
+
     if (!$conf['useacl']) return false;
 
     // try to load auth backend from plugins


### PR DESCRIPTION
An empty remote user should not be set at all. Seems like some webservers always set the environment var, even if no authentication happened. I'd argue that this is wrong, but this should fix the behaviour.