### PR TITLE
drop tilde from title. fixes #4347

### DIFF
--- a/inc/parser/renderer.php
+++ b/inc/parser/renderer.php
@@ -891,6 +891,9 @@ abstract class Doku_Renderer extends Plugin
     {
         global $conf;
 
+        // remove relative namespace
+        $name = ltrim($name, '~');
+
         //if there is a hash we use the ancor name only
         [$name, $hash] = sexplode('#', $name, 2);
         if ($hash) return $hash;


### PR DESCRIPTION
When a link with the page relative shortcut is used and no title is given, the given ID is used to create a title. In this case, the tilde should be removed from the title.

[[~SomeThing]] -> SomeThing