### PR TITLE
increase HTTP timeout for extension cli

### DIFF
--- a/lib/plugins/extension/Installer.php
+++ b/lib/plugins/extension/Installer.php
@@ -288,7 +288,7 @@ class Installer
         // download
         $http = new DokuHTTPClient();
         $http->max_bodysize = 0;
-        $http->timeout = 25; //max. 25 sec
+        $http->timeout = 60*5; //max. 5min
         $http->keep_alive = false; // we do single ops here, no need for keep-alive
         $http->agent = 'DokuWiki HTTP Client (Extension Manager)';
 


### PR DESCRIPTION
I'd like to be able to set the HTTP timeout when installing plugins from the cli. Some packages (e.g. dw2pdf) are quite large, so a default of 25s might be too low on slow (e.g. mobile) lines.