### PR TITLE
fix: ACL check fails with user containing special chars

### DIFF
--- a/inc/auth.php
+++ b/inc/auth.php
@@ -776,7 +776,7 @@ function auth_aclcheck_cb($data)
             if (!$auth->isCaseSensitive() && $acl[1] !== '@ALL') {
                 $acl[1] = PhpString::strtolower($acl[1]);
             }
-            if (!in_array($acl[1], $groups)) {
+            if (!in_array(auth_nameencode($acl[1]), $groups)) {
                 continue;
             }
             if ($acl[2] > AUTH_DELETE) $acl[2] = AUTH_DELETE; //no admins in the ACL!


### PR DESCRIPTION
User name is nameencoded when it's added in groups array. But it's not nameencoded when it's read from the ACL file. So, the comparison fails.

Fix the issue https://github.com/dokuwiki/dokuwiki/issues/4385