### PR TITLE
use http_build_query() in buildURLparams()

### DIFF
--- a/_test/tests/inc/parser/parser_media.test.php
+++ b/_test/tests/inc/parser/parser_media.test.php
@@ -31,7 +31,7 @@ class TestOfDoku_Parser_Media extends TestOfDoku_Parser {
         $source = '<source src="http://some.where.far/away.ogv" type="video/ogg" />';
         $this->assertEquals(substr($url,67,64),$source);
         // work around random token
-        $a_first_part = '<a href="' . DOKU_BASE . 'lib/exe/fetch.php?cache=&amp;tok=';
+        $a_first_part = '<a href="' . DOKU_BASE . 'lib/exe/fetch.php?tok=';
         $a_second_part = '&amp;media=http%3A%2F%2Fsome.where.far%2Faway.ogv" class="media mediafile mf_ogv" title="http://some.where.far/away.ogv">';
 
         $substr_start = 132;
@@ -119,12 +119,12 @@ class TestOfDoku_Parser_Media extends TestOfDoku_Parser {
         $this->assertNotSame(false, $substr_start, 'Substring not found.');
 
         // find $a_webm in $url
-        $a_webm = '<a href="' . DOKU_BASE . 'lib/exe/fetch.php?id=&amp;cache=&amp;media=wiki:kind_zu_katze.webm" class="media mediafile mf_webm" title="wiki:kind_zu_katze.webm (99.1'."\xC2\xA0".'KB)">kind_zu_katze.webm</a>';
+        $a_webm = '<a href="' . DOKU_BASE . 'lib/exe/fetch.php?media=wiki:kind_zu_katze.webm" class="media mediafile mf_webm" title="wiki:kind_zu_katze.webm (99.1'."\xC2\xA0".'KB)">kind_zu_katze.webm</a>';
         $substr_start = strpos($url, $a_webm, $substr_start + strlen($source_ogv));
         $this->assertNotSame(false, $substr_start, 'Substring not found.');
 
         // find $a_webm in $url
-        $a_ogv = '<a href="' . DOKU_BASE . 'lib/exe/fetch.php?id=&amp;cache=&amp;media=wiki:kind_zu_katze.ogv" class="media mediafile mf_ogv" title="wiki:kind_zu_katze.ogv (44.8'."\xC2\xA0".'KB)">kind_zu_katze.ogv</a>';
+        $a_ogv = '<a href="' . DOKU_BASE . 'lib/exe/fetch.php?media=wiki:kind_zu_katze.ogv" class="media mediafile mf_ogv" title="wiki:kind_zu_katze.ogv (44.8'."\xC2\xA0".'KB)">kind_zu_katze.ogv</a>';
         $substr_start = strpos($url, $a_ogv, $substr_start + strlen($a_webm));
         $this->assertNotSame(false, $substr_start, 'Substring not found.');
 

--- a/inc/common.php
+++ b/inc/common.php
@@ -346,24 +346,15 @@ function mediainfo()
 /**
  * Build an string of URL parameters
  *
- * @param array $params array with key-value pairs
+ * @see http_build_query()
+ * @param array|object $params the data to encode
  * @param string $sep series of pairs are separated by this character
  * @return string query string
- * @author Andreas Gohr
  *
  */
 function buildURLparams($params, $sep = '&amp;')
 {
-    $url = '';
-    $amp = false;
-    foreach ($params as $key => $val) {
-        if ($amp) $url .= $sep;
-
-        $url .= rawurlencode($key) . '=';
-        $url .= rawurlencode((string)$val);
-        $amp = true;
-    }
-    return $url;
+    return http_build_query($params, '', $sep, PHP_QUERY_RFC3986);
 }
 
 /**


### PR DESCRIPTION
buildURLparams() is used all throughout the code, but its implementation was overly simplistic. This changes it to use the much better builtin http_build_query() function. This allows for correct encoding of array values or deeper nested structures.