### PR TITLE
allow dialogs overflow in y-direction

### DIFF
--- a/lib/tpl/dokuwiki/css/design.less
+++ b/lib/tpl/dokuwiki/css/design.less
@@ -299,7 +299,8 @@ form.search {
     border-radius: 2px;
     padding: 1.556em 2em 2em;
     margin-bottom: .5em;
-    overflow: hidden;
+    overflow-x: clip;
+    overflow-y: visible;
     word-wrap: break-word;
 }
 


### PR DESCRIPTION
In the dokuwiki template, an overflow:hidden was meant to keep oversized content within the article area. However this can interfere with pseudo-dropdowns on very small pages.

This changes the behavior to clip on x-axis only while keeping overflows visible in the y direction.

This fixes a rare issue and should not have any effects on normal use anyway.