### PR TITLE
Change print font to Arial and sans-serif, same as screen font

### DIFF
--- a/lib/tpl/dokuwiki/css/print.css
+++ b/lib/tpl/dokuwiki/css/print.css
@@ -5,7 +5,7 @@
  */
 
 body {
-    font: normal 87.5%/1.3 Garamond, Baskerville, "Hoefler Text", "Nimbus Roman No9 L", serif;
+    font: normal 87.5%/1.4 Arial, sans-serif;
     background-color: #fff;
     color: #000;
 }


### PR DESCRIPTION
Since the change introduced in commit 264643e6c38cdf7f423c404c10bb63d0e7d7a5c4 (2013-02-03) for [FS#2645 Ugly fonts when printing with new template](https://bugs.dokuwiki.org/2645.html) (2012-10-17), the printed text is difficult for me to read. Garamond font is too thin and too small.

I propose to change the font to Arial, sans-serif, the same font that is used for the screen.

Before: [Example-print-dokuwiki-orig.pdf](https://github.com/user-attachments/files/18975122/Example-print-dokuwiki-orig.pdf)

After: [Example-print-dokuwiki-b.pdf](https://github.com/user-attachments/files/18975125/Example-print-dokuwiki-b.pdf)
