### PR TITLE
allow passing current revision to mediaFN

### DIFF
--- a/_test/tests/inc/pageutils_mediaFN.test.php
+++ b/_test/tests/inc/pageutils_mediaFN.test.php
@@ -9,15 +9,11 @@ class mediafn_test extends DokuWikiTest
      */
     public function mediaFNProvider()
     {
-
-        $currentRev = filemtime(DOKU_TMP_DATA . 'media/wiki/dokuwiki-128.png');
-
         return [
             // current
             ['wiki:dokuwiki-128.png', '', true, DOKU_TMP_DATA . 'media/wiki/dokuwiki-128.png'],
             ['wiki:dokuwiki-128.png', false, true, DOKU_TMP_DATA . 'media/wiki/dokuwiki-128.png'],
             ['wiki:dokuwiki-128.png', null, true, DOKU_TMP_DATA . 'media/wiki/dokuwiki-128.png'],
-            ['wiki:dokuwiki-128.png', $currentRev, true, DOKU_TMP_DATA . 'media/wiki/dokuwiki-128.png'],
 
             // old
             ['wiki:dokuwiki-128.png', 1234567890, true, DOKU_TMP_DATA . 'media_attic/wiki/dokuwiki-128.1234567890.png'],
@@ -35,6 +31,13 @@ class mediafn_test extends DokuWikiTest
     {
         $result = mediaFN($id, $rev, $clean);
         $this->assertEquals($expected, $result);
+    }
+
+    public function testMediaFNCurrentRev()
+    {
+        $currentRev = filemtime(DOKU_TMP_DATA . 'media/wiki/dokuwiki-128.png');
+        $result = mediaFN('wiki:dokuwiki-128.png', $currentRev);
+        $this->assertEquals(DOKU_TMP_DATA . 'media/wiki/dokuwiki-128.png', $result);
     }
 
 }

--- a/_test/tests/inc/pageutils_mediaFN.test.php
+++ b/_test/tests/inc/pageutils_mediaFN.test.php
@@ -1,0 +1,41 @@
+<?php
+
+
+class mediafn_test extends DokuWikiTest
+{
+
+    /**
+     * Data provider for testMediaFN
+     */
+    public function mediaFNProvider()
+    {
+
+        $currentRev = filemtime(DOKU_TMP_DATA . 'media/wiki/dokuwiki-128.png');
+
+        return [
+            // current
+            ['wiki:dokuwiki-128.png', '', true, DOKU_TMP_DATA . 'media/wiki/dokuwiki-128.png'],
+            ['wiki:dokuwiki-128.png', false, true, DOKU_TMP_DATA . 'media/wiki/dokuwiki-128.png'],
+            ['wiki:dokuwiki-128.png', null, true, DOKU_TMP_DATA . 'media/wiki/dokuwiki-128.png'],
+            ['wiki:dokuwiki-128.png', $currentRev, true, DOKU_TMP_DATA . 'media/wiki/dokuwiki-128.png'],
+
+            // old
+            ['wiki:dokuwiki-128.png', 1234567890, true, DOKU_TMP_DATA . 'media_attic/wiki/dokuwiki-128.1234567890.png'],
+
+            // cleaning
+            ['wiki:dokuwiki*oink.png', '', true, DOKU_TMP_DATA . 'media/wiki/dokuwiki_oink.png'],
+            ['wiki:dokuwiki*oink.png', '', false, DOKU_TMP_DATA . 'media/wiki/dokuwiki%2Aoink.png'],
+        ];
+    }
+
+    /**
+     * @dataProvider mediaFNProvider
+     */
+    public function testMediaFN($id, $rev, $clean, $expected)
+    {
+        $result = mediaFN($id, $rev, $clean);
+        $this->assertEquals($expected, $result);
+    }
+
+}
+

--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -444,26 +444,40 @@ function metaFiles($id)
  *
  * The filename is URL encoded to protect Unicode chars
  *
- * @author Andreas Gohr <andi@splitbrain.org>
- * @author Kate Arzamastseva <pshns@ukr.net>
- *
- * @param string     $id  media id
+ * @param string $id media id
  * @param string|int $rev empty string or revision timestamp
  * @param bool $clean
  *
  * @return string full path
+ * @author Andreas Gohr <andi@splitbrain.org>
+ * @author Kate Arzamastseva <pshns@ukr.net>
+ *
  */
 function mediaFN($id, $rev = '', $clean = true)
 {
     global $conf;
     if ($clean) $id = cleanID($id);
     $id = str_replace(':', '/', $id);
-    if (empty($rev)) {
-        $fn = $conf['mediadir'] . '/' . utf8_encodeFN($id);
+    $rev = (int) $rev;;
+
+
+    // current file
+    $simple = $conf['mediadir'] . '/' . utf8_encodeFN($id);
+
+    // if a revision is given and it matches the current revision, return the current file
+    if ($rev !== 0) {
+        $current = @filemtime($simple);
+        if ($current === $rev) {
+            return $simple;
+        }
+    }
+
+    if ($rev === 0) {
+        $fn = $simple;
     } else {
-        $ext = mimetype($id);
-        $name = substr($id, 0, -1 * strlen($ext[0]) - 1);
-        $fn = $conf['mediaolddir'] . '/' . utf8_encodeFN($name . '.' . ( (int) $rev ) . '.' . $ext[0]);
+        [$ext] = mimetype($id);
+        $name = substr($id, 0, -1 * strlen($ext) - 1);
+        $fn = $conf['mediaolddir'] . '/' . utf8_encodeFN($name . '.' . $rev . '.' . $ext);
     }
     return $fn;
 }

--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -458,8 +458,7 @@ function mediaFN($id, $rev = '', $clean = true)
     global $conf;
     if ($clean) $id = cleanID($id);
     $id = str_replace(':', '/', $id);
-    $rev = (int) $rev;;
-
+    $rev = (int) $rev;
 
     // current file
     $simple = $conf['mediadir'] . '/' . utf8_encodeFN($id);


### PR DESCRIPTION
This allows passing the current revision's timestamp as $rev parameter and get the path to the file in data/meta. Previously you had to always pass an empty revision to access the current file.

This makes it easier to use the return of MediaChangeLog::getRevisions() to access any revision.

This will also fix the issues encountered in #4147