### PR TITLE
use B flag for Apache rewrite rules. fixes #4238

### DIFF
--- a/.htaccess.dist
+++ b/.htaccess.dist
@@ -22,13 +22,13 @@
 ## $conf['userewrite'] = 1 - not needed for rewrite mode 2
 #RewriteEngine on
 #
-#RewriteRule ^_media/(.*)              lib/exe/fetch.php?media=$1  [QSA,L]
-#RewriteRule ^_detail/(.*)             lib/exe/detail.php?media=$1  [QSA,L]
-#RewriteRule ^_export/([^/]+)/(.*)     doku.php?do=export_$1&id=$2  [QSA,L]
+#RewriteRule ^_media/(.*)              lib/exe/fetch.php?media=$1  [QSA,L,B]
+#RewriteRule ^_detail/(.*)             lib/exe/detail.php?media=$1  [QSA,L,B]
+#RewriteRule ^_export/([^/]+)/(.*)     doku.php?do=export_$1&id=$2  [QSA,L,B]
 #RewriteRule ^$                        doku.php  [L]
 #RewriteCond %{REQUEST_FILENAME}       !-f
 #RewriteCond %{REQUEST_FILENAME}       !-d
-#RewriteRule (.*)                      doku.php?id=$1  [QSA,L]
+#RewriteRule (.*)                      doku.php?id=$1  [QSA,L,B]
 #RewriteRule ^index.php$               doku.php
 #
 ## Not all installations will require the following line.  If you do,


### PR DESCRIPTION
The B flag reenables passing spaces and other special chars in URLs to be picked up (and cleaned) by DokuWiki's ID processing.

The flag has been available in non-broken form since Apache 2.2.9 and should be safe to use.

See https://stackoverflow.com/q/3460643