### PR TITLE
Menu: check context visibility after assembling items

### DIFF
--- a/inc/Menu/AbstractMenu.php
+++ b/inc/Menu/AbstractMenu.php
@@ -43,6 +43,12 @@ abstract class AbstractMenu implements MenuInterface
     {
         $data = ['view' => $this->view, 'items' => []];
         Event::createAndTrigger('MENU_ITEMS_ASSEMBLY', $data, [$this, 'loadItems']);
+
+        $data['items'] = array_filter(
+            $data['items'],
+            fn($item) => $item instanceof AbstractItem && $item->visibleInContext($this->context)
+        );
+
         return $data['items'];
     }
 
@@ -59,7 +65,6 @@ abstract class AbstractMenu implements MenuInterface
                 $class = "\\dokuwiki\\Menu\\Item\\$class";
                 /** @var AbstractItem $item */
                 $item = new $class();
-                if (!$item->visibleInContext($this->context)) continue;
                 $data['items'][] = $item;
             } catch (\RuntimeException $ignored) {
                 // item not available

--- a/inc/Menu/Item/Admin.php
+++ b/inc/Menu/Item/Admin.php
@@ -12,17 +12,19 @@ class Admin extends AbstractItem
     /** @inheritdoc */
     public function __construct()
     {
+        global $INPUT;
+        global $INFO;
+
         parent::__construct();
 
+        if (!$INPUT->server->str('REMOTE_USER')) {
+            throw new \RuntimeException("admin is only for logged in users");
+        }
+
+        if (!isset($INFO) || !$INFO['ismanager']) {
+            throw new \RuntimeException("admin is only for managers and above");
+        }
+
         $this->svg = DOKU_INC . 'lib/images/menu/settings.svg';
-    }
-
-    /** @inheritdoc */
-    public function visibleInContext($ctx)
-    {
-        global $INFO;
-        if (!$INFO['ismanager']) return false;
-
-        return parent::visibleInContext($ctx);
     }
 }

--- a/lib/exe/detail.php
+++ b/lib/exe/detail.php
@@ -6,7 +6,7 @@ if (!defined('DOKU_INC')) define('DOKU_INC', __DIR__ . '/../../');
 if (!defined('DOKU_MEDIADETAIL')) define('DOKU_MEDIADETAIL', 1);
 
 // define all DokuWiki globals here (needed within test requests but also helps to keep track)
-global $INPUT, $IMG, $ID, $REV, $SRC, $ERROR, $AUTH;
+global $INPUT, $INFO, $IMG, $ID, $REV, $SRC, $ERROR, $AUTH;
 
 require_once(DOKU_INC . 'inc/init.php');
 


### PR DESCRIPTION
This addresses #4400. By checking the context visibility after the assembly, the context is properly checked for plugin items.