### PR TITLE
fix button border css

### DIFF
--- a/lib/styles/screen.css
+++ b/lib/styles/screen.css
@@ -71,7 +71,8 @@ div.notify {
 /* media manager popup toggle buttons */
 
 #media__popup_content button.button {
-    border: 1px outset;
+    border-width: 1px;
+    border-style: outset;
 }
 
 #media__popup_content button.selected {


### PR DESCRIPTION
Firefox (at least 128 esr on Linux) displayed a solid black border around all buttons inside the popup which makes it impossible to see which button was pressed. This change makes the outset/inset look work as it probably was intended.

This is what it looked like before the change:
![dokuwiki_before](https://github.com/user-attachments/assets/d28eedb5-db71-4b63-8677-8748f90be69e)

This is what it looks like after the change:
![dokuwiki_after](https://github.com/user-attachments/assets/7cfdadc5-7875-4da1-91a3-3015b2cf03e3)
