### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,13 @@
 * text eol=lf
 
+*.csv binary
+*.ttf binary
+*.zip binary
+*.gz binary
+*.db binary
+
+*.webp binary
+*.jpg binary
 *.png binary
 *.gif binary
 *.ico binary


### PR DESCRIPTION
When comparing files, I encounter issues with this file extensions in Linux versus Windows, as they are not binary identical.