### PR TITLE
dwpage: Detect that workingfile is a directory

### DIFF
--- a/bin/dwpage.php
+++ b/bin/dwpage.php
@@ -217,6 +217,10 @@ class PageCLI extends CLI
             $localfile = getcwd() . '/' . PhpString::basename($wiki_fn);
         }
 
+        if (is_dir($localfile)) {
+            $this->fatal("Working file $localfile cannot be a directory");
+        }
+
         if (!file_exists(dirname($localfile))) {
             $this->fatal("Directory " . dirname($localfile) . " does not exist");
         }


### PR DESCRIPTION
And provide meaningful error message instead of PHP warning.

Fixes #4461

New error message:
```
$ php bin/dwpage.php checkout ns:page /tmp

☠ Working file /tmp cannot be a directory
```

