### PR TITLE
WIP: 32bit IPv6 unpack

### DIFF
--- a/inc/Ip.php
+++ b/inc/Ip.php
@@ -100,7 +100,15 @@ class Ip
             ];
         } else {
             // IPv6.
-            $result = unpack('Jupper/Jlower', $binary);
+            if(PHP_INT_SIZE == 8) { // 64-bit arch
+               $result = unpack('Jupper/Jlower', $binary);
+            } else { // 32-bit
+                // unpack into four 32-bit unsigned ints, recombine as 128-bit string using bc math
+                $parts = unpack('N4', $binary);
+                $upper = bcadd(bcmul($parts[1], bcpow('2', 96)), bcmul($parts[2], bcpow('2', 64)));
+                $lower = bcadd(bcmul($parts[3], bcpow('2', 32)), $parts[4]);
+                return [$upper, $lower];
+            }
             $result['version'] = 6;
             return $result;
         }


### PR DESCRIPTION
For #4485

At least two blocking points
1. not sure where or how to put in tests: `_test/tests/inc/Ip.test.php` is intimidating :)
2. `ipv6_upper_lower_32` probably doesn't match `unpack('Jupper/Jlower', inet_pton($ip))`. I thought `unpack('J')` would never be negative. But it flips to max neg at `8000:0000:0000:0000`?!

```
$ip = inet_pton('ffff:ffff:ffff:fff0:ffff:ffff:ffff:ffff');
print_r(unpack('J2', $ip));
Array
(
    [1] => -16
    [2] => -1
)
print_r(unpack('N4', $ip));
Array
(
    [1] => 4294967295
    [2] => 4294967280
    [3] => 4294967295
    [4] => 4294967295
)


print_r(unpack('J2',inet_pton('8000:0000:0000:0000:7fff:ffff:ffff:ffff')));
Array
(
    [1] => -9223372036854775808
    [2] => 9223372036854775807
)

```