### PR TITLE
Update wordblock.conf to include some unicode substitutions

### DIFF
--- a/conf/wordblock.conf
+++ b/conf/wordblock.conf
@@ -27,3 +27,11 @@ flatsinmumbai\.co\.in
 https?:\/\/(\S*?)penny-?stock
 mattressreview\.biz
 (just|simply) (my|a) profile (site|webpage|page)
+# Unicode substitutions:
+tһe
+contｒol
+ᥙnable
+tⲟ
+thｅ
+thɑt
+availɑЬility


### PR DESCRIPTION
These lookalike characters seem to be slipped in to evade other spam filters. But since there's no(?) legitimate use for "words" like "tһe" (middle character is "cyrillic small letter shha"), we can use them to detect spam, of which they are characteristic. This is, admittedly, a slipshod and scattershot approach, just copying some funny-letters words I saw in spam on a dokuwiki in the wild.