### PR TITLE
Fix translation issues for usermanager plugin

### DIFF
--- a/lib/plugins/usermanager/admin.php
+++ b/lib/plugins/usermanager/admin.php
@@ -722,7 +722,7 @@ class admin_plugin_usermanager extends AdminPlugin
         $selected = array_keys($selected);
 
         if (in_array($_SERVER['REMOTE_USER'], $selected)) {
-            msg("You can't delete yourself!", -1);
+            msg($this->lang['delete_fail_self'], -1);
             return false;
         }
 

--- a/lib/plugins/usermanager/lang/en/lang.php
+++ b/lib/plugins/usermanager/lang/en/lang.php
@@ -41,6 +41,7 @@ $lang['summary']     = 'Displaying users %1$d-%2$d of %3$d found. %4$d users tot
 $lang['nonefound']   = 'No users found. %d users total.';
 $lang['delete_ok']   = '%d users deleted';
 $lang['delete_fail'] = '%d failed deleting.';
+$lang['delete_fail_self'] = 'You can\'t delete yourself';
 $lang['update_ok']   = 'User updated successfully';
 $lang['update_fail'] = 'User update failed';
 $lang['update_exists'] = 'User name change failed, the specified user name (%s) already exists (any other changes will be applied).';

--- a/lib/plugins/usermanager/lang/en/lang.php
+++ b/lib/plugins/usermanager/lang/en/lang.php
@@ -79,9 +79,9 @@ $lang['import_downloadfailures'] = 'Download Failures as CSV for correction';
 
 $lang['addUser_error_missing_pass'] = 'Please either set a password or activate user notification to enable password generation.';
 $lang['addUser_error_pass_not_identical'] = 'The entered passwords were not identical.';
-$lang['addUser_error_modPass_disabled'] = 'Modifing passwords is currently disabled';
+$lang['addUser_error_modPass_disabled'] = 'Modifying passwords is currently disabled';
 $lang['addUser_error_name_missing'] = 'Please enter a name for the new user.';
-$lang['addUser_error_modName_disabled'] = 'Modifing names is currently disabled.';
-$lang['addUser_error_mail_missing'] = 'Please enter an Email-Adress for the new user.';
-$lang['addUser_error_modMail_disabled'] = 'Modifing Email-Adresses is currently disabled.';
+$lang['addUser_error_modName_disabled'] = 'Modifying names is currently disabled.';
+$lang['addUser_error_mail_missing'] = 'Please enter an email address for the new user.';
+$lang['addUser_error_modMail_disabled'] = 'Modifying email adresses is currently disabled.';
 $lang['addUser_error_create_event_failed'] = 'A plugin prevented the new user being added. Review possible other messages for more information.';


### PR DESCRIPTION
- Replace hardcoded message by localized string
- Fix typos in English strings

Fixes #4507