### PR TITLE
Improve core.getPageLinks response

### DIFF
--- a/_test/tests/Remote/ApiCoreTest.php
+++ b/_test/tests/Remote/ApiCoreTest.php
@@ -566,27 +566,29 @@ You can use up to five different levels of',
         $localdoku = [
             'type' => 'local',
             'page' => 'DokuWiki',
-            'href' => DOKU_BASE . DOKU_SCRIPT . '?id=DokuWiki'
+            'href' => DOKU_BASE . DOKU_SCRIPT . '?id=dokuwiki',
+            'title' => 'DokuWiki'
         ];
         $expected = [
             $localdoku,
             [
                 'type' => 'extern',
                 'page' => 'http://www.freelists.org',
-                'href' => 'http://www.freelists.org'
+                'href' => 'http://www.freelists.org',
+                'title' => 'freelists.org'
             ],
             [
                 'type' => 'interwiki',
                 'page' => 'rfc>1855',
-                'href' => 'https://tools.ietf.org/html/rfc1855'
+                'href' => 'https://tools.ietf.org/html/rfc1855',
+                'title' => 'RFC 1855 - Netiquette Guidelines'
             ],
             [
                 'type' => 'extern',
                 'page' => 'http://www.catb.org/~esr/faqs/smart-questions.html',
-                'href' => 'http://www.catb.org/~esr/faqs/smart-questions.html'
-            ],
-            $localdoku,
-            $localdoku
+                'href' => 'http://www.catb.org/~esr/faqs/smart-questions.html',
+                'title' => 'How To Ask Questions The Smart Way'
+            ]
         ];
 
         $this->assertEqualResult(
@@ -596,6 +598,47 @@ You can use up to five different levels of',
 
         $this->expectExceptionCode(121);
         $this->remote->call('core.getPageLinks', ['page' => 'foobar']);
+    }
+
+    public function testGetPageLinksWithHashesTitlesAndDuplicates()
+    {
+        saveWikiText(
+            'api:links',
+            implode("\n", [
+                '[[api:target#Target Heading|Internal Hash]]',
+                '[[api:target#Target Heading|Internal Hash Duplicate]]',
+                '[[api:target#Other Heading|Other Internal Hash]]',
+                '[[rfc>1855#3.1.1|RFC Section]]',
+                '[[rfc>1855#3.1.1|RFC Section Duplicate]]',
+            ]),
+            'test'
+        );
+
+        $expected = [
+            [
+                'type' => 'local',
+                'page' => 'api:target#Target Heading',
+                'href' => DOKU_BASE . DOKU_SCRIPT . '?id=api:target#target_heading',
+                'title' => 'Internal Hash'
+            ],
+            [
+                'type' => 'local',
+                'page' => 'api:target#Other Heading',
+                'href' => DOKU_BASE . DOKU_SCRIPT . '?id=api:target#other_heading',
+                'title' => 'Other Internal Hash'
+            ],
+            [
+                'type' => 'interwiki',
+                'page' => 'rfc>1855#3.1.1',
+                'href' => 'https://tools.ietf.org/html/rfc1855#3.1.1',
+                'title' => 'RFC Section'
+            ],
+        ];
+
+        $this->assertEqualResult(
+            $expected,
+            $this->remote->call('core.getPageLinks', ['page' => 'api:links'])
+        );
     }
 
     //core.getPageBackLinks

--- a/inc/Remote/ApiCore.php
+++ b/inc/Remote/ApiCore.php
@@ -7,6 +7,7 @@ use dokuwiki\ChangeLog\PageChangeLog;
 use dokuwiki\ChangeLog\MediaChangeLog;
 use dokuwiki\Extension\AuthPlugin;
 use dokuwiki\Extension\Event;
+use dokuwiki\File\PageResolver;
 use dokuwiki\Remote\Response\Link;
 use dokuwiki\Remote\Response\Media;
 use dokuwiki\Remote\Response\MediaChange;
@@ -26,7 +27,7 @@ use dokuwiki\Utf8\Sort;
 class ApiCore
 {
     /** @var int Increased whenever the API is changed */
-    public const API_VERSION = 14;
+    public const API_VERSION = 15;
 
     /**
      * Returns details about the core methods
@@ -514,7 +515,7 @@ class ApiCore
      *
      * This returns a list of links found in the given page. This includes internal, external and interwiki links
      *
-     * If a link occurs multiple times on the page, it will be returned multiple times.
+     * If a link occurs multiple times on the page, it will be returned only once.
      *
      * Read access for the given page is needed and page has to exist.
      *
@@ -522,9 +523,6 @@ class ApiCore
      * @return Link[] A list of links found on the given page
      * @throws AccessDeniedException
      * @throws RemoteException
-     * @todo returning link titles would be a nice addition
-     * @todo hash handling seems not to be correct
-     * @todo maybe return the same link only once?
      * @author Michael Klier <chi@chimeric.de>
      */
     public function getPageLinks($page)
@@ -543,19 +541,83 @@ class ApiCore
         foreach ($ins as $in) {
             switch ($in[0]) {
                 case 'internallink':
-                    $links[] = new Link('local', $in[1][0], wl($in[1][0]));
+                    $link = $this->makeInternalLink($page, $Renderer, $in[1][0], $in[1][1] ?? null);
+                    $links[$link->href] ??= $link;
                     break;
                 case 'externallink':
-                    $links[] = new Link('extern', $in[1][0], $in[1][0]);
+                    $link = new Link(
+                        'extern',
+                        $in[1][0],
+                        $in[1][0],
+                        $this->getLinkTitle($in[1][1] ?? null, '<' . $in[1][0] . '>')
+                    );
+                    $links[$link->href] ??= $link;
                     break;
                 case 'interwikilink':
                     $url = $Renderer->_resolveInterWiki($in[1][2], $in[1][3]);
-                    $links[] = new Link('interwiki', $in[1][0], $url);
+                    $link = new Link(
+                        'interwiki',
+                        $in[1][0],
+                        $url,
+                        $this->getLinkTitle($in[1][1] ?? null, $in[1][3])
+                    );
+                    $links[$link->href] ??= $link;
                     break;
             }
         }
 
-        return ($links);
+        return array_values($links);
+    }
+
+    /**
+     * Create a link response for an internal link, matching the XHTML renderer's page and hash resolution
+     *
+     * @param string $contextPage The page the link was found on
+     * @param Doku_Renderer_xhtml $renderer Renderer helper for title and hash handling
+     * @param string $id Raw link target from parser instructions
+     * @param string|array|null $name Raw link title from parser instructions
+     * @return Link
+     */
+    private function makeInternalLink($contextPage, Doku_Renderer_xhtml $renderer, $id, $name)
+    {
+        $linkPage = $id;
+        $params = '';
+        $parts = explode('?', $id, 2);
+        if (count($parts) === 2) {
+            $id = $parts[0];
+            $params = $parts[1];
+        }
+
+        $default = $renderer->_simpleTitle($id);
+        $resolvedId = (new PageResolver($contextPage))->resolveId($id, '', true);
+        [$pageId, $hash] = sexplode('#', $resolvedId, 2);
+
+        $href = wl($pageId, $params);
+        if ($hash) {
+            $href .= '#' . $renderer->_headerToLink($hash);
+        }
+
+        return new Link('local', $linkPage, $href, $this->getLinkTitle($name, $default));
+    }
+
+    /**
+     * Return a text title for a link instruction
+     *
+     * @param string|array|null $title Parsed link title
+     * @param string $default Default title
+     * @return string
+     */
+    private function getLinkTitle($title, $default)
+    {
+        if (is_array($title)) {
+            return $title['title'] ?? $title['src'] ?? $default;
+        }
+
+        if ($title === null || trim($title) === '') {
+            return $default;
+        }
+
+        return $title;
     }
 
     /**

--- a/inc/Remote/Response/Link.php
+++ b/inc/Remote/Response/Link.php
@@ -4,23 +4,27 @@ namespace dokuwiki\Remote\Response;
 
 class Link extends ApiResponse
 {
-    /** @var string The type of this link: `internal`, `external` or `interwiki` */
+    /** @var string The type of this link: `local`, `extern` or `interwiki` */
     public $type;
     /** @var string The wiki page this link points to, same as `href` for external links */
     public $page;
     /** @var string A hyperlink pointing to the linked target */
     public $href;
+    /** @var string The title of this link */
+    public $title;
 
     /**
-     * @param string $type One of `internal`, `external` or `interwiki`
+     * @param string $type One of `local`, `extern` or `interwiki`
      * @param string $page The wiki page this link points to, same as `href` for external links
      * @param string $href A hyperlink pointing to the linked target
+     * @param string $title The title of this link
      */
-    public function __construct($type, $page, $href)
+    public function __construct($type, $page, $href, $title = '')
     {
         $this->type = $type;
         $this->page = $page;
         $this->href = $href;
+        $this->title = $title;
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
Fixes #4145.

This is my first contribution to DokuWiki. I would appreciate feedback on the code and whether this approach is acceptable for the project.

## Summary

- resolve internal page links through the normal page resolver so links with `#hash` fragments return rendered-style hrefs
- preserve interwiki hash fragments in returned hrefs
- include link titles in `core.getPageLinks` responses
- return unique links keyed by final `href`, keeping the first occurrence
- bump the API version because the response shape and duplicate behavior changed

## Tests

- `php -d session.save_path=/tmp vendor/bin/phpunit --configuration phpunit.xml tests/Remote/ApiCoreTest.php`
- `vendor/bin/phpcs --standard=phpcs_MigrationAdjustments.xml ../inc/Remote/ApiCore.php ../inc/Remote/Response/Link.php tests/Remote/ApiCoreTest.php`
