### PR TITLE
Add AI Policy document

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,5 @@ composer.lock export-ignore
 _test export-ignore
 _test/** export-ignore
 lib/plugins/testing export-ignore
+AI_POLICY.md export-ignore
+CONTRIBUTING.md export-ignore

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,64 @@
+# AI Policy
+
+AI assisted coding is okay if you understand the code you are contributing and can explain it in your own words.
+You should be able to answer questions about the code you contribute without copying responses from AI.
+
+All code merged into the DokuWiki codebase **must be reviewed and approved by a human**, regardless of wether it was
+added by a long-time maintainer or first-time contributor. Each commit must have a responsible human author attached.
+Refrain from "co-authored-by" or similar tags that attribute the contribution to an AI.
+
+**AI may not be used to communicate** with maintainers. This includes comments on pull requests and issues as well as
+pull request and issue descriptions. If an AI generated output is relevant to the discussion, it should be included in
+a quote block and accompanied by human commentary explaining its relevance and implications.
+
+**It's okay to use AI to translate** comments to English as long as it reflects your own voice. Consider including the
+original text in a quote block so readers speaking both languages can refer back to it.
+
+**Drive-by AI contributions are not welcome**. If you are a first-time contributor it is expected that you will explain
+your motivation for contributing to the DokuWiki project. How are you using DokuWiki and why is the code you are
+contributing important to you? "I saw the issue and let my AI write a fix" is not an acceptable motivation. Tickets
+marked as "good first-issue" are not an invitation for AI fixes - they are meant to be a starting point for new human
+contributors to get involved in the project. We want contributions to be driven by people who actually use DokuWiki and
+care about the project, not by people who are just looking for an easy way to get a contribution on their GitHub
+profile.
+
+Failure to follow this policy may result in your contribution being rejected and/or your account being blocked.
+
+## Background
+
+If you are new to the Open-Source world, you might be wondering about the existence of above policy or the hostility
+towards AI and your contributions in general.
+
+If you really want to contribute to Open-Source projects because you want to help, the list of short quotes and links
+below will give you a starting point to better understand the concerns and issues Open Source maintainers face.
+
+> All these people who submit drive-by pull requests to my projects are pushing me to spend more and more of my time
+> reviewing and merging code that was extruded by machines.
+>
+> from ["I Am Not a Reverse Centaur"](https://blog.miguelgrinberg.com/post/i-am-not-a-reverse-centaur)
+
+
+> Since I don't really know you, I always have to assume that you might be trying to sneak in something malicious along
+> with your changes, which makes reviewing and merging them riskier than implementing them myself.\
+> […]\
+> For these reasons, it's just easier if I make the code changes myself (with the help of an LLM).
+>
+> from ["I don't want your PRs anymore"](https://dpc.pw/posts/i-dont-want-your-prs-anymore/)
+
+
+> What most people don’t realize is that evaluating and merging changes is far harder than writing new code.
+> Understanding how a change fits into the existing codebase, its history, and its plans requires knowledge that’s
+> partly
+> invisible — not in the code, not in the comments, not in the issues. It’s in the maintainer’s head. And some of it is
+> deeply creative work, requiring the kind of judgment no model can replicate.
+>
+> from ["The Maintainer’s Dilemma"](https://spf13.com/p/the-maintainers-dilemma/)
+
+
+> […] a contribution is not finished when the pull request is opened. […] AI changes the cost of creating the first
+> version. It does not make that second part disappear.\
+> […]\
+> The useful question is not “did AI touch this?”. The useful question is: does the person submitting this understand
+> it, validate it, and take responsibility for it?
+>
+> from ["Open source was not ready for AI-speed contributions"](https://frenck.dev/open-source-was-not-ready-for-ai-speed-contributions/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+## Use of AI
+
+All use of AI in contributions must follow the
+[AI Policy](AI_POLICY.md).
+
+Contributions not following the AI Policy will be closed.


### PR DESCRIPTION
Inspired by the [Generative AI usage policy and general LLM discussion](https://forum.dokuwiki.org/d/26031-generative-ai-usage-policy-and-general-llm-discussion) in the forum and recent drive-by AI PRs (#4658, #4643, #4640) this is a first attempt at defining what we want from contributions and contributors.

This policy is aimed at the core repository only. A policy on plugins maintainence and ownership (and their listing on dokuwiki.org) is beyond the scope of this PR.