### PR TITLE
fix(ci): build release archives with git archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,6 @@
 *.ico binary
 *.xcf binary
 
-.git export-ignore
 .gitattributes export-ignore
 .github export-ignore
 .github/** export-ignore

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -56,23 +56,18 @@ jobs:
 
       - name: Build Archives
         run: |
-          git ls-files | while read path; do
-            if git check-attr export-ignore -- "$path" | grep -q 'export-ignore: set'; then
-              echo "Deleting $path"
-              rm -f "$path"
-            fi
+          echo "====== PlayGround ======" > playground.txt
+          # the tree is archived rather than the commit, because for a commit git
+          # prepends a pax global header that php-archive unpacks as a stray file
+          # tar.umask keeps the group-writable bit out of the archived modes
+          for FORMAT in tgz zip; do
+            git -c tar.umask=0022 archive --format=$FORMAT -9 \
+              --prefix="dokuwiki-${{ env.current_file }}/data/pages/playground/" \
+              --add-file=playground.txt \
+              --prefix="dokuwiki-${{ env.current_file }}/" \
+              --output="dokuwiki-${{ env.current_file }}.$FORMAT" \
+              'HEAD^{tree}'
           done
-          find . -type d -empty -delete
-          mkdir -p data/pages/playground
-          echo "====== PlayGround ======" > data/pages/playground/playground.txt
-          cd ..
-          mv ${{ github.event.repository.name }} "dokuwiki-${{ env.current_file }}"
-          tar -czvf "dokuwiki-${{ env.current_file }}.tgz" dokuwiki-${{ env.current_file }}
-          zip -r "dokuwiki-${{ env.current_file }}.zip" dokuwiki-${{ env.current_file }}
-          rm -rf "dokuwiki-${{ env.current_file }}"
-          mkdir ${{ github.event.repository.name }}
-          mv "dokuwiki-${{ env.current_version }}.tgz" ${{ github.event.repository.name }}/
-          mv "dokuwiki-${{ env.current_version }}.zip" ${{ github.event.repository.name }}/
 
       - name: Release to Github
         id: release


### PR DESCRIPTION
This is an alternative fix for #4720, which replaces #4722

Instead of reading `.gitattributes` ourselves to prune the checkout, we use `git archive`. This is more correct, automatically excludes `.git` and should also be faster.
