### PR TITLE
security(actions): resolve action names to exactly one class

### DIFF
--- a/_test/tests/Action/ActionTest.php
+++ b/_test/tests/Action/ActionTest.php
@@ -7,6 +7,10 @@ use dokuwiki\Action\AbstractUserAction;
 use dokuwiki\Action\Exception\ActionAclRequiredException;
 use dokuwiki\Action\Exception\ActionDisabledException;
 use dokuwiki\Action\Exception\ActionUserRequiredException;
+use dokuwiki\Action\Exception\NoActionException;
+use dokuwiki\Action\Export;
+use dokuwiki\Action\Media;
+use dokuwiki\Action\ProfileDelete;
 
 class ActionTest extends \DokuWikiTest
 {
@@ -119,6 +123,99 @@ class ActionTest extends \DokuWikiTest
         } catch (\Exception $e) {
             $this->assertSame(ActionDisabledException::class, get_class($e), $e);
         }
+    }
+
+    /**
+     * A disabled action may not be reached by spelling its name differently
+     *
+     * @dataProvider dataProvider
+     * @param $name
+     */
+    public function testDisabledActionNameVariants($name)
+    {
+        $this->assertTrue(true); // mark as not risky
+        if ($name == 'Show') return; // disabling show does not work
+
+        $classname = 'dokuwiki\\Action\\' . $name;
+        /** @var \dokuwiki\Action\AbstractAction $class */
+        $class = new $classname();
+
+        $actionname = $class->getActionName();
+
+        $variants = [
+            $actionname . '_',
+            '_' . $actionname,
+            '__' . $actionname . '__',
+            $actionname . '_zzz',
+        ];
+        // export_zzz is a renderer mode of its own, so it is not the disabled export
+        if ($class instanceof Export) array_pop($variants);
+
+        global $conf;
+        $conf['useacl'] = 1;
+        $conf['subscribers'] = 1;
+        $conf['disableactions'] = $actionname;
+        $_SERVER['REMOTE_USER'] = 'someone';
+
+        $router = \dokuwiki\ActionRouter::getInstance(true);
+        foreach ($variants as $variant) {
+            try {
+                $router->checkAction($router->loadAction($variant));
+                $this->fail("'$variant' was accepted while '$actionname' is disabled");
+            } catch (NoActionException | ActionDisabledException $e) {
+                $this->assertTrue(true); // mark as not risky
+            }
+        }
+    }
+
+    /**
+     * These are all the shapes an action name may have
+     */
+    public function testLoadActionAcceptedNames()
+    {
+        $router = \dokuwiki\ActionRouter::getInstance(true);
+
+        $this->assertInstanceOf(Media::class, $router->loadAction('media'));
+        $this->assertInstanceOf(ProfileDelete::class, $router->loadAction('profile_delete'));
+        $this->assertInstanceOf(Export::class, $router->loadAction('export_raw'));
+
+        // renderer plugins may provide components, the mode is taken from the action name
+        $export = $router->loadAction('export_odt_book');
+        $this->assertInstanceOf(Export::class, $export);
+        $this->assertSame('export_odt_book', $export->getActionName());
+    }
+
+    /**
+     * Names that look like an action but are none
+     *
+     * @return array
+     */
+    public function invalidNameProvider()
+    {
+        return [
+            ['media_'],
+            ['_media'],
+            ['__media__'],
+            ['media_zzz'],
+            ['me_dia'],
+            ['medi_a'],
+            ['export_raw_'],
+            ['_export_raw'],
+            ['export__raw'],
+            ['profile_delete_'],
+        ];
+    }
+
+    /**
+     * Anything not matching the accepted shapes is no action at all
+     *
+     * @dataProvider invalidNameProvider
+     * @param $name
+     */
+    public function testLoadActionRejectedNames($name)
+    {
+        $this->expectException(NoActionException::class);
+        \dokuwiki\ActionRouter::getInstance(true)->loadAction($name);
     }
 
     /**

--- a/_test/tests/Action/ActionTest.php
+++ b/_test/tests/Action/ActionTest.php
@@ -30,6 +30,8 @@ class ActionTest extends \DokuWikiTest
             array('Register', AUTH_NONE, array('exists' => true, 'ismanager' => false)),
             array('Resendpwd', AUTH_NONE, array('exists' => true, 'ismanager' => false)),
             array('Backlink', AUTH_NONE, array('exists' => true, 'ismanager' => false)),
+            array('Authtoken', AUTH_NONE, array('exists' => true, 'ismanager' => false)),
+            array('Plugin', AUTH_NONE, array('exists' => true, 'ismanager' => false)),
 
             array('Revert', AUTH_EDIT, array('exists' => true, 'ismanager' => false)),
             array('Revert', AUTH_EDIT, array('exists' => true, 'ismanager' => true)),
@@ -52,6 +54,7 @@ class ActionTest extends \DokuWikiTest
             // aliases
             array('Cancel', AUTH_NONE, array('exists' => true, 'ismanager' => false)),
             array('Recover', AUTH_NONE, array('exists' => true, 'ismanager' => false)),
+            array('Redirect', AUTH_NONE, array('exists' => true, 'ismanager' => false)),
 
             // EDITING existing page
             array('Save', AUTH_EDIT, array('exists' => true, 'ismanager' => false)),
@@ -126,10 +129,52 @@ class ActionTest extends \DokuWikiTest
     }
 
     /**
+     * The class names of all actions, the base classes they inherit from excluded
+     *
+     * Using this instead of a hand kept list means a newly added action is covered by
+     * the tests it feeds without anyone having to remember them.
+     *
+     * @return array
+     */
+    public function actionClassProvider()
+    {
+        $data = [];
+        foreach (glob(DOKU_INC . 'inc/Action/*.php') as $file) {
+            $name = basename($file, '.php');
+            if (!(new \ReflectionClass('dokuwiki\\Action\\' . $name))->isInstantiable()) continue;
+            $data[$name] = [$name];
+        }
+        return $data;
+    }
+
+    /**
+     * Every action is reachable by the name it reports and no two of them share a name
+     *
+     * A class name spelled differently from the action name is not caught here, because
+     * class names match case insensitively once the class has been loaded.
+     *
+     * @dataProvider actionClassProvider
+     * @param string $name the class name of the action
+     */
+    public function testActionNameResolvesToItsClass($name)
+    {
+        $classname = 'dokuwiki\\Action\\' . $name;
+        /** @var \dokuwiki\Action\AbstractAction $class */
+        $class = new $classname();
+
+        $loaded = \dokuwiki\ActionRouter::getInstance(true)->loadAction($class->getActionName());
+        $this->assertSame($classname, get_class($loaded));
+    }
+
+    /**
      * A disabled action may not be reached by spelling its name differently
      *
-     * @dataProvider dataProvider
-     * @param $name
+     * None of the variants names an action today, so they are rejected before the disable
+     * check is ever reached. Should one of them start to resolve, the disable check has to
+     * catch it, which is why both outcomes are accepted here.
+     *
+     * @dataProvider actionClassProvider
+     * @param string $name the class name of the action
      */
     public function testDisabledActionNameVariants($name)
     {

--- a/_test/tests/Action/ActionTest.php
+++ b/_test/tests/Action/ActionTest.php
@@ -219,6 +219,35 @@ class ActionTest extends \DokuWikiTest
     }
 
     /**
+     * The base classes the actions inherit from are no actions themselves
+     *
+     * Should a base class ever be named without the abstract prefix, this fails and the
+     * exclusion in loadAction() needs to be adjusted.
+     */
+    public function testLoadActionRejectedBaseClasses()
+    {
+        $router = \dokuwiki\ActionRouter::getInstance(true);
+
+        $checked = 0;
+        foreach (glob(DOKU_INC . 'inc/Action/*.php') as $file) {
+            $name = basename($file, '.php');
+            $class = 'dokuwiki\\Action\\' . $name;
+            // the reflection autoloads the class, so a lowercase spelling of it resolves from here on
+            if ((new \ReflectionClass($class))->isInstantiable()) continue;
+            $checked++;
+
+            try {
+                $router->loadAction(strtolower($name));
+                $this->fail("base class $class was accepted as an action");
+            } catch (NoActionException $e) {
+                $this->assertTrue(true); // mark as not risky
+            }
+        }
+
+        $this->assertGreaterThan(0, $checked, 'no base classes were found to check');
+    }
+
+    /**
      * Actions inheriting from AbstractAclAction should have an ACL enabled check
      *
      * @dataProvider dataProvider

--- a/_test/tests/inc/actions_act_clean.test.php
+++ b/_test/tests/inc/actions_act_clean.test.php
@@ -1,0 +1,36 @@
+<?php
+
+class actions_act_clean_test extends DokuWikiTest {
+
+    /**
+     * Requested actions and their normalized form
+     *
+     * @return array
+     */
+    public function data() {
+        return [
+            // input, expected
+            ['media', 'media'],
+            ['MEDIA', 'media'], // case is folded, not rejected
+            ['  media  ', 'media'],
+            ['me<>dia', 'media'],
+            ['export_raw', 'export_raw'],
+            ['export_html', 'export_xhtml'],
+            ['export_htmlbody', 'export_xhtmlbody'],
+            ['dw2pdf_export0', 'dw2pdf_export0'], // digits are kept
+            [['save' => 1], 'save'], // image buttons submit the action as array key
+            [null, 'show'],
+            ['', 'show'],
+            ['+++', 'show'],
+        ];
+    }
+
+    /**
+     * @dataProvider data
+     * @param array|string|null $input
+     * @param string $expected
+     */
+    public function test_act_clean($input, $expected) {
+        $this->assertSame($expected, act_clean($input));
+    }
+}

--- a/doku.php
+++ b/doku.php
@@ -25,7 +25,7 @@ global $ACT, $INPUT, $QUERY, $ID, $REV, $DATE_AT, $IDX,
 
 
 if (isset($_SERVER['HTTP_X_DOKUWIKI_DO'])) {
-    $ACT = trim(strtolower($_SERVER['HTTP_X_DOKUWIKI_DO']));
+    $ACT = $_SERVER['HTTP_X_DOKUWIKI_DO'];
 } elseif (!empty($_REQUEST['idx'])) {
     $ACT = 'index';
 } elseif (isset($_REQUEST['do'])) {
@@ -110,7 +110,7 @@ if ($conf['allowdebug'] && $ACT == 'debug') {
 if (
     !$INFO['exists'] &&
     ($conf['send404'] || preg_match('/^(robots\.txt|sitemap\.xml(\.gz)?|favicon\.ico|crossdomain\.xml)$/', $ID)) &&
-    ($ACT == 'show' || (!is_array($ACT) && str_starts_with($ACT, 'export_')))
+    ($ACT == 'show' || str_starts_with($ACT, 'export_'))
 ) {
     header('HTTP/1.0 404 Not Found');
 }

--- a/inc/Action/ProfileDelete.php
+++ b/inc/Action/ProfileDelete.php
@@ -15,6 +15,19 @@ use dokuwiki\Extension\AuthPlugin;
  */
 class ProfileDelete extends AbstractUserAction
 {
+    /**
+     * ProfileDelete constructor.
+     *
+     * The name of this action carries an underscore and thus cannot be derived
+     * from the class name.
+     *
+     * @param string $actionname the name of this action
+     */
+    public function __construct($actionname = 'profile_delete')
+    {
+        parent::__construct($actionname);
+    }
+
     /** @inheritdoc */
     public function minimumPermission()
     {

--- a/inc/ActionRouter.php
+++ b/inc/ActionRouter.php
@@ -37,7 +37,8 @@ class ActionRouter
      * ActionRouter constructor. Singleton, thus protected!
      *
      * Sets up the correct action based on the $ACT global. Writes back
-     * the selected action to $ACT
+     * the selected action to $ACT. Reaching this point means an action is
+     * dispatched, so a request that named none asks for show.
      */
     protected function __construct()
     {
@@ -47,6 +48,7 @@ class ActionRouter
         $this->disabled = explode(',', $conf['disableactions']);
         $this->disabled = array_map(trim(...), $this->disabled);
 
+        $ACT ??= 'show';
         $this->setupAction($ACT);
         $ACT = $this->action->getActionName();
     }

--- a/inc/ActionRouter.php
+++ b/inc/ActionRouter.php
@@ -8,7 +8,9 @@ use dokuwiki\Action\Exception\ActionDisabledException;
 use dokuwiki\Action\Exception\ActionException;
 use dokuwiki\Action\Exception\FatalException;
 use dokuwiki\Action\Exception\NoActionException;
+use dokuwiki\Action\Export;
 use dokuwiki\Action\Plugin;
+use dokuwiki\Action\ProfileDelete;
 
 /**
  * Class ActionRouter
@@ -45,7 +47,6 @@ class ActionRouter
         $this->disabled = explode(',', $conf['disableactions']);
         $this->disabled = array_map(trim(...), $this->disabled);
 
-        $ACT = act_clean($ACT);
         $this->setupAction($ACT);
         $ACT = $this->action->getActionName();
     }
@@ -167,28 +168,30 @@ class ActionRouter
     /**
      * Load the given action
      *
-     * This translates the given name to a class name by uppercasing the first letter.
-     * Underscores translate to camelcase names. For actions with underscores, the different
-     * parts are removed beginning from the end until a matching class is found. The instatiated
-     * Action will always have the full original action set as Name
+     * Each action name maps to exactly one class and each class to exactly one name.
+     * A name made up of letters and digits maps to the class of the same name with an
+     * uppercased first letter. The export modes and profile_delete are the only names
+     * containing underscores. Anything else is not an action name at all.
      *
-     * Example: 'export_raw' -> ExportRaw then 'export' -> 'Export'
+     * Example: 'media' -> Media, 'export_odt_book' -> Export
      *
-     * @param $actionname
+     * @param string $actionname a normalized action name as returned by act_clean()
      * @return AbstractAction
-     * @throws NoActionException
+     * @throws NoActionException when the name does not name an action
      */
     public function loadAction($actionname)
     {
-        $actionname = strtolower($actionname); // FIXME is this needed here? should we run a cleanup somewhere else?
-        $parts = explode('_', $actionname);
-        while ($parts !== []) {
-            $load = implode('_', $parts);
-            $class = 'dokuwiki\\Action\\' . str_replace('_', '', ucwords($load, '_'));
-            if (class_exists($class)) {
-                return new $class($actionname);
-            }
-            array_pop($parts);
+        // the only actions carrying underscores in their name
+        if (preg_match('/^export_[a-z0-9]+(_[a-z0-9]+)*$/', $actionname)) {
+            return new Export($actionname);
+        }
+        if ($actionname === 'profile_delete') {
+            return new ProfileDelete($actionname);
+        }
+
+        if (preg_match('/^[a-z0-9]+$/', $actionname)) {
+            $class = 'dokuwiki\\Action\\' . ucfirst($actionname);
+            if (class_exists($class)) return new $class($actionname);
         }
 
         throw new NoActionException();

--- a/inc/ActionRouter.php
+++ b/inc/ActionRouter.php
@@ -112,7 +112,7 @@ class ActionRouter
             msg('Action unknown: ' . hsc($actionname), -1);
             $actionname = 'show';
             $this->transitionAction($presetup, $actionname);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->handleFatalException($e);
         }
     }
@@ -147,10 +147,10 @@ class ActionRouter
     /**
      * Aborts all processing with a message
      *
-     * When a FataException instanc is passed, the code is treated as Status code
+     * When a FatalException instance is passed, the code is treated as Status code
      *
-     * @param \Exception|FatalException $e
-     * @throws FatalException during unit testing
+     * @param \Throwable $e
+     * @throws \Throwable during unit testing
      */
     protected function handleFatalException(\Throwable $e)
     {
@@ -170,10 +170,10 @@ class ActionRouter
     /**
      * Load the given action
      *
-     * Each action name maps to exactly one class and each class to exactly one name.
-     * A name made up of letters and digits maps to the class of the same name with an
-     * uppercased first letter. The export modes and profile_delete are the only names
-     * containing underscores. Anything else is not an action name at all.
+     * Each action name maps to exactly one class. A name made up of letters and digits maps
+     * to the class of the same name with an uppercased first letter, except for the base
+     * classes, whose names all start with abstract. The export modes and profile_delete are
+     * the only names containing underscores. Anything else is not an action name at all.
      *
      * Example: 'media' -> Media, 'export_odt_book' -> Export
      *
@@ -191,7 +191,8 @@ class ActionRouter
             return new ProfileDelete($actionname);
         }
 
-        if (preg_match('/^[a-z0-9]+$/', $actionname)) {
+        // class names match case insensitively, so the base class names have to be excluded
+        if (preg_match('/^[a-z0-9]+$/', $actionname) && !str_starts_with($actionname, 'abstract')) {
             $class = 'dokuwiki\\Action\\' . ucfirst($actionname);
             if (class_exists($class)) return new $class($actionname);
         }

--- a/inc/actions.php
+++ b/inc/actions.php
@@ -46,11 +46,15 @@ function act_sendheaders($headers)
 }
 
 /**
- * Sanitize the action command
+ * Normalize the action command
+ *
+ * This is applied once while the request is initialized, so everything reading the
+ * $ACT global sees a lowercase name made up of letters, digits and underscores only.
+ * Whether that name actually is an existing action is decided later by the ActionRouter.
  *
  * @author Andreas Gohr <andi@splitbrain.org>
  *
- * @param array|string $act
+ * @param array|string|null $act the action as given by the request
  * @return string
  */
 function act_clean($act)
@@ -65,7 +69,7 @@ function act_clean($act)
 
     //remove all bad chars
     $act = strtolower($act);
-    $act = preg_replace('/[^1-9a-z_]+/', '', $act);
+    $act = preg_replace('/[^0-9a-z_]+/', '', $act);
 
     if ($act == 'export_html') $act = 'export_xhtml';
     if ($act == 'export_htmlbody') $act = 'export_xhtmlbody';

--- a/inc/actions.php
+++ b/inc/actions.php
@@ -48,8 +48,8 @@ function act_sendheaders($headers)
 /**
  * Normalize the action command
  *
- * This is applied once while the request is initialized, so everything reading the
- * $ACT global sees a lowercase name made up of letters, digits and underscores only.
+ * This is applied once while the request is initialized, so a requested action in the
+ * $ACT global is a lowercase name made up of letters, digits and underscores only.
  * Whether that name actually is an existing action is decided later by the ActionRouter.
  *
  * @author Andreas Gohr <andi@splitbrain.org>

--- a/inc/common.php
+++ b/inc/common.php
@@ -326,7 +326,7 @@ function jsinfo()
     //export minimal info to JS, plugins can add more
     $JSINFO['id'] = $ID;
     $JSINFO['namespace'] = isset($INFO) ? (string)$INFO['namespace'] : '';
-    $JSINFO['ACT'] = act_clean($ACT);
+    $JSINFO['ACT'] = $ACT;
     $JSINFO['useHeadingNavigation'] = (int)useHeading('navigation');
     $JSINFO['useHeadingContent'] = (int)useHeading('content');
 }

--- a/inc/common.php
+++ b/inc/common.php
@@ -326,7 +326,7 @@ function jsinfo()
     //export minimal info to JS, plugins can add more
     $JSINFO['id'] = $ID;
     $JSINFO['namespace'] = isset($INFO) ? (string)$INFO['namespace'] : '';
-    $JSINFO['ACT'] = $ACT;
+    $JSINFO['ACT'] = act_clean($ACT);
     $JSINFO['useHeadingNavigation'] = (int)useHeading('navigation');
     $JSINFO['useHeadingContent'] = (int)useHeading('content');
 }

--- a/inc/init.php
+++ b/inc/init.php
@@ -53,6 +53,10 @@ if (!defined('DOKU_E_LEVEL')) {
 // autoloader
 require_once(DOKU_INC . 'inc/load.php');
 
+// normalize the action requested by the entry script, everything below relies on this
+global $ACT;
+$ACT = act_clean($ACT);
+
 // avoid caching issues #1594
 header('Vary: Cookie');
 
@@ -176,7 +180,6 @@ if (!defined('DOKU_TPLINC')) {
 // enable gzip compression if supported
 $httpAcceptEncoding = $_SERVER['HTTP_ACCEPT_ENCODING'] ?? '';
 $conf['gzip_output'] &= (str_contains($httpAcceptEncoding, 'gzip'));
-global $ACT;
 if (
     $conf['gzip_output'] &&
         !defined('DOKU_DISABLE_GZIP_OUTPUT') &&

--- a/inc/init.php
+++ b/inc/init.php
@@ -54,8 +54,9 @@ if (!defined('DOKU_E_LEVEL')) {
 require_once(DOKU_INC . 'inc/load.php');
 
 // normalize the action requested by the entry script, everything below relies on this
+// entry scripts that dispatch no action leave $ACT unset, which is a signal of its own
 global $ACT;
-$ACT = act_clean($ACT);
+if (isset($ACT)) $ACT = act_clean($ACT);
 
 // avoid caching issues #1594
 header('Vary: Cookie');


### PR DESCRIPTION
$conf['disableactions'] could be bypassed by spelling an action name with extra underscores (?do=media_, ?do=_media, ?do=media_zzz). Names were resolved to a class fuzzily, by deleting underscores and by dropping underscore separated parts from the end until a class matched, while the disable check compared the raw request string. 33 of the 34 core actions were affected.

Action names and classes now map to each other one to one, so the name an action is requested by is necessarily the name it is checked against. Only the export modes and profile_delete carry underscores, anything else is no action at all.

$ACT is normalized once while the request is initialized instead of being cleaned again by whoever needed it clean. This also puts the case fold before the disable check, without which ?do=MEDIA would reach Media while the check compared MEDIA. Entry points that never set $ACT get the show default from the same call.

ProfileDelete no longer derives its name from the class name, which gave profiledelete instead of profile_delete.

Also fixes act_clean() stripping the digit 0 from action names.

fixes #4731