### PR TITLE
security(actions): resolve action names to exactly one class (simplified)

### DIFF
--- a/_test/tests/Action/ActionTest.php
+++ b/_test/tests/Action/ActionTest.php
@@ -7,6 +7,10 @@ use dokuwiki\Action\AbstractUserAction;
 use dokuwiki\Action\Exception\ActionAclRequiredException;
 use dokuwiki\Action\Exception\ActionDisabledException;
 use dokuwiki\Action\Exception\ActionUserRequiredException;
+use dokuwiki\Action\Exception\NoActionException;
+use dokuwiki\Action\Export;
+use dokuwiki\Action\Media;
+use dokuwiki\Action\ProfileDelete;
 
 class ActionTest extends \DokuWikiTest
 {
@@ -119,6 +123,55 @@ class ActionTest extends \DokuWikiTest
         } catch (\Exception $e) {
             $this->assertSame(ActionDisabledException::class, get_class($e), $e);
         }
+    }
+
+    /**
+     * These are all the shapes an action name may have
+     */
+    public function testLoadActionAcceptedNames()
+    {
+        $router = \dokuwiki\ActionRouter::getInstance(true);
+
+        $this->assertInstanceOf(Media::class, $router->loadAction('media'));
+        $this->assertInstanceOf(ProfileDelete::class, $router->loadAction('profile_delete'));
+        $this->assertInstanceOf(Export::class, $router->loadAction('export_raw'));
+
+        // renderer plugins may provide components, the mode is taken from the action name
+        $export = $router->loadAction('export_odt_book');
+        $this->assertInstanceOf(Export::class, $export);
+        $this->assertSame('export_odt_book', $export->getActionName());
+    }
+
+    /**
+     * Names that look like an action but are none
+     *
+     * @return array
+     */
+    public function invalidNameProvider()
+    {
+        return [
+            ['media_'],
+            ['_media'],
+            ['__media__foo_bar___'],
+            ['media_zzz'],
+            ['me_dia'],
+            ['export_raw_'],
+            ['_export_raw'],
+            ['export__raw'],
+            ['profile_delete_'],
+        ];
+    }
+
+    /**
+     * A disabled action may not be reached by spelling its name differently
+     *
+     * @dataProvider invalidNameProvider
+     * @param string $name the requested action name
+     */
+    public function testLoadActionRejectedNames($name)
+    {
+        $this->expectException(NoActionException::class);
+        \dokuwiki\ActionRouter::getInstance(true)->loadAction($name);
     }
 
     /**

--- a/inc/ActionRouter.php
+++ b/inc/ActionRouter.php
@@ -8,7 +8,9 @@ use dokuwiki\Action\Exception\ActionDisabledException;
 use dokuwiki\Action\Exception\ActionException;
 use dokuwiki\Action\Exception\FatalException;
 use dokuwiki\Action\Exception\NoActionException;
+use dokuwiki\Action\Export;
 use dokuwiki\Action\Plugin;
+use dokuwiki\Action\ProfileDelete;
 
 /**
  * Class ActionRouter
@@ -167,28 +169,32 @@ class ActionRouter
     /**
      * Load the given action
      *
-     * This translates the given name to a class name by uppercasing the first letter.
-     * Underscores translate to camelcase names. For actions with underscores, the different
-     * parts are removed beginning from the end until a matching class is found. The instatiated
-     * Action will always have the full original action set as Name
+     * Each action name maps to exactly one class. A name made up of letters and digits maps to
+     * the class of the same name with an uppercased first letter. The export modes and
+     * profile_delete are the only action names containing underscores. Any other name does not
+     * name an action.
      *
-     * Example: 'export_raw' -> ExportRaw then 'export' -> 'Export'
+     * Example: 'media' -> Media, 'export_odt_book' -> Export
      *
-     * @param $actionname
+     * @param string $actionname the name of the action to load
      * @return AbstractAction
-     * @throws NoActionException
+     * @throws NoActionException when the name does not name an action
      */
     public function loadAction($actionname)
     {
-        $actionname = strtolower($actionname); // FIXME is this needed here? should we run a cleanup somewhere else?
-        $parts = explode('_', $actionname);
-        while ($parts !== []) {
-            $load = implode('_', $parts);
-            $class = 'dokuwiki\\Action\\' . str_replace('_', '', ucwords($load, '_'));
-            if (class_exists($class)) {
-                return new $class($actionname);
-            }
-            array_pop($parts);
+        $actionname = strtolower($actionname);
+
+        // the only action names carrying underscores
+        if (preg_match('/^export_[a-z0-9]+(_[a-z0-9]+)*$/', $actionname)) {
+            return new Export($actionname);
+        }
+        if ($actionname === 'profile_delete') {
+            return new ProfileDelete($actionname);
+        }
+
+        if (preg_match('/^[a-z0-9]+$/', $actionname)) {
+            $class = 'dokuwiki\\Action\\' . ucfirst($actionname);
+            if (class_exists($class)) return new $class($actionname);
         }
 
         throw new NoActionException();


### PR DESCRIPTION
Reviewing #4732 surfaced a couple of issues, that have been addressed in additional commits. However, I am not comfortable with pushing all those changes as a hotfix. This PR contains a more minimal approach fixing #4731 without touching how act_clean() works.

We might merge or adapt #4732 later.