### PR TITLE
fix: honor textonly mode for email user links

### DIFF
--- a/_test/tests/Ui/PageDiffTest.php
+++ b/_test/tests/Ui/PageDiffTest.php
@@ -10,6 +10,44 @@ use dokuwiki\Ui\PageDiff;
 class PageDiffTest extends \DokuWikiTest
 {
     /**
+     * Regression test for issue #4718: with showuseras = email and the default
+     * mailguard = hex, the revision dropdown labels show the plain address
+     * instead of double-encoded obfuscation entities.
+     */
+    public function testRevisionOptionsShowPlainEmail()
+    {
+        global $conf, $INPUT;
+        $conf['showuseras'] = 'email';
+        $conf['mailguard'] = 'hex';
+        $_SERVER['REMOTE_USER'] = 'testuser';
+
+        $page = 'pagediff_email';
+        saveWikiText($page, 'first content', 'create', false);
+        clearstatcache();
+        $this->waitForTick(true);
+        saveWikiText($page, 'second content', 'edit', false);
+        clearstatcache();
+        $this->waitForTick(true);
+
+        $INPUT->remove('rev');
+        $INPUT->remove('rev2');
+
+        $diff = new PageDiff($page);
+        global $INFO;
+        $INFO['id'] = $page;
+        $this->callInaccessibleMethod($diff, 'handle', []);
+        $this->callInaccessibleMethod($diff, 'preProcess', []);
+        $changelog = $this->getInaccessibleProperty($diff, 'changelog');
+        $revs = $changelog->getRevisions(0, 100);
+        $options = $this->callInaccessibleMethod($diff, 'buildRevisionOptions', ['older', $revs]);
+
+        $labels = implode(' | ', array_column($options, 'label'));
+        $this->assertStringContainsString('arthur@example.com', $labels, 'dropdown label should show the plain email address');
+        $this->assertStringNotContainsString('&amp;#', $labels, 'dropdown label must not contain double-encoded entities');
+        $this->assertStringNotContainsString('&#', $labels, 'dropdown label must not contain any entity-encoded email');
+    }
+
+    /**
      * Determine which two revisions PageDiff would compare for a ?do=diff request
      * that carries no rev or rev2 parameters.
      *

--- a/_test/tests/inc/UserlinkTextonlyTest.php
+++ b/_test/tests/inc/UserlinkTextonlyTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace dokuwiki\test\inc;
+
+/**
+ * Regression tests for issue #4718: userlink()/editorinfo() must return plain
+ * text (no HTML entities) when called with $textonly = true, even when the
+ * wiki is configured to show editors as email addresses.
+ */
+class UserlinkTextonlyTest extends \DokuWikiTest
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        $_SERVER['REMOTE_USER'] = 'testuser';
+    }
+
+    /**
+     * With showuseras = email and the default mailguard = hex, the text-only
+     * variant must return the raw address instead of the obfuscated entities.
+     */
+    public function testTextonlyEmailReturnsPlainAddress(): void
+    {
+        global $conf;
+        $conf['showuseras'] = 'email';
+        $conf['mailguard'] = 'hex';
+
+        $this->assertEquals('arthur@example.com', userlink('testuser', true));
+    }
+
+    /**
+     * Same contract for showuseras = email_link.
+     */
+    public function testTextonlyEmailLinkReturnsPlainAddress(): void
+    {
+        global $conf;
+        $conf['showuseras'] = 'email_link';
+        $conf['mailguard'] = 'hex';
+
+        $this->assertEquals('arthur@example.com', userlink('testuser', true));
+    }
+
+    /**
+     * The HTML variant must keep returning obfuscated entities: the fix must
+     * not weaken mail obfuscation for non-text output.
+     */
+    public function testHtmlEmailStillObfuscated(): void
+    {
+        global $conf;
+        $conf['showuseras'] = 'email';
+        $conf['mailguard'] = 'hex';
+
+        $html = userlink('testuser', false);
+        $this->assertStringContainsString('&#', $html);
+        $this->assertStringNotContainsString('arthur@example.com', $html);
+    }
+}

--- a/inc/common.php
+++ b/inc/common.php
@@ -1624,7 +1624,7 @@ function userlink($username = null, $textonly = false)
                         break;
                     case 'email':
                     case 'email_link':
-                        $data['name'] = MailUtils::obfuscate($info['mail']);
+                        $data['name'] = $textonly ? $info['mail'] : MailUtils::obfuscate($info['mail']);
                         break;
                 }
             } else {


### PR DESCRIPTION
Fixes #4718

**Issue:** With `showuseras` set to `email` or `email_link`, user links returned the mail address as HTML entities even in text-only mode. PageDiff's revision dropdown escapes option labels a second time, so emails were displayed mangled (e.g. `&amp;#97;&#114;...`).

**Fix:** `userlink()` now returns the plain mail address when called with `$textonly = true`, matching the existing username branch. HTML output keeps the obfuscated address. Added unit tests for the direct text-only calls plus a PageDiff regression test.
