### PR TITLE
Extension plugin: list without using remote repository

### DIFF
--- a/lib/plugins/extension/Extension.php
+++ b/lib/plugins/extension/Extension.php
@@ -439,7 +439,17 @@ class Extension implements \Stringable
     public function isBundled()
     {
         $this->loadRemoteInfo();
-        return $this->remoteInfo['bundled'] ?? in_array(
+        return $this->remoteInfo['bundled'] ?? $this->isBundledNoRemote();
+    }
+
+    /**
+     * If the extension is bundled (no remote access)
+     *
+     * @return bool If the extension is bundled
+     */
+    public function isBundledNoRemote()
+    {
+        return in_array(
             $this->getId(),
             [
                 'authad',

--- a/lib/plugins/extension/Notice.php
+++ b/lib/plugins/extension/Notice.php
@@ -39,7 +39,6 @@ class Notice
         $this->extension = $extension;
 
         $this->checkFolder();
-        $this->checkPHPVersion();
         $this->checkPermissions();
         $this->checkUnusedAuth();
         $this->checkGit();
@@ -56,6 +55,7 @@ class Notice
 
         $self->checkSecurity();
         $self->checkURLChange();
+        $self->checkPHPVersion();
         $self->checkDependencies();
         $self->checkConflicts();
         $self->checkUpdateMessage();

--- a/lib/plugins/extension/Notice.php
+++ b/lib/plugins/extension/Notice.php
@@ -39,7 +39,6 @@ class Notice
         $this->extension = $extension;
 
         $this->checkFolder();
-        $this->checkPermissions();
         $this->checkUnusedAuth();
         $this->checkGit();
     }
@@ -59,6 +58,7 @@ class Notice
         $self->checkDependencies();
         $self->checkConflicts();
         $self->checkUpdateMessage();
+        $self->checkPermissions();
 
         return $self->notices;
     }

--- a/lib/plugins/extension/Notice.php
+++ b/lib/plugins/extension/Notice.php
@@ -38,13 +38,8 @@ class Notice
         $this->helper = plugin_load('helper', 'extension');
         $this->extension = $extension;
 
-        $this->checkSecurity();
-        $this->checkURLChange();
         $this->checkFolder();
         $this->checkPHPVersion();
-        $this->checkDependencies();
-        $this->checkConflicts();
-        $this->checkUpdateMessage();
         $this->checkPermissions();
         $this->checkUnusedAuth();
         $this->checkGit();
@@ -56,6 +51,24 @@ class Notice
      * @return string[][] array of notices grouped by type
      */
     public static function list(Extension $extension): array
+    {
+        $self = new self($extension);
+
+        $self->checkSecurity();
+        $self->checkURLChange();
+        $self->checkDependencies();
+        $self->checkConflicts();
+        $self->checkUpdateMessage();
+
+        return $self->notices;
+    }
+
+    /**
+     * Get all local notices for the extension
+     *
+     * @return string[][] array of notices grouped by type
+     */
+    public static function listNoRemote(Extension $extension): array
     {
         $self = new self($extension);
         return $self->notices;

--- a/lib/plugins/extension/cli.php
+++ b/lib/plugins/extension/cli.php
@@ -273,7 +273,7 @@ class cli_plugin_extension extends CLIPlugin
             Repository::getInstance()->initExtensions(array_keys($extensions));
         }
 
-        $this->listExtensions($extensions, $showdetails, $filter);
+        $this->listExtensions($extensions, $showdetails, $filter, $noremote);
         return 0;
     }
 
@@ -318,7 +318,7 @@ class cli_plugin_extension extends CLIPlugin
                 }
             } else {
                 $ecolor = null;
-                $date = $ext->getLastUpdate();
+                $date = $noremote ? null : $ext->getLastUpdate();
                 $vcolor = null;
             }
 

--- a/lib/plugins/extension/cli.php
+++ b/lib/plugins/extension/cli.php
@@ -47,7 +47,7 @@ class cli_plugin_extension extends CLIPlugin
         $options->registerCommand('list', 'List installed extensions');
         $options->registerOption('verbose', 'Show detailed extension information', 'v', false, 'list');
         $options->registerOption('filter', 'Filter by this status', 'f', 'status', 'list');
-        $options->registerOption('no-remote', 'Don\'t contact the plugin repository', 'n', false, 'list');
+        $options->registerOption('no-remote', 'Don\'t contact the plugin repository; this means most issues won\'t be checked', 'n', false, 'list');
 
         // upgrade
         $options->registerCommand('upgrade', 'Update all installed extensions to their latest versions');

--- a/lib/plugins/extension/cli.php
+++ b/lib/plugins/extension/cli.php
@@ -47,6 +47,7 @@ class cli_plugin_extension extends CLIPlugin
         $options->registerCommand('list', 'List installed extensions');
         $options->registerOption('verbose', 'Show detailed extension information', 'v', false, 'list');
         $options->registerOption('filter', 'Filter by this status', 'f', 'status', 'list');
+        $options->registerOption('no-remote', 'Don\'t contact the plugin repository', 'n', false, 'list');
 
         // upgrade
         $options->registerCommand('upgrade', 'Update all installed extensions to their latest versions');
@@ -77,16 +78,18 @@ class cli_plugin_extension extends CLIPlugin
     /** @inheritdoc */
     protected function main(Options $options)
     {
-        $repo = Repository::getInstance();
-        try {
-            $repo->checkAccess();
-        } catch (ExtensionException $e) {
-            $this->warning($e->getMessage());
+        if (! $options->getOpt('no-remote')) {
+            $repo = Repository::getInstance();
+            try {
+                $repo->checkAccess();
+            } catch (ExtensionException $e) {
+                $this->warning($e->getMessage());
+            }
         }
 
         switch ($options->getCmd()) {
             case 'list':
-                $ret = $this->cmdList($options->getOpt('verbose'), $options->getOpt('filter', ''));
+                $ret = $this->cmdList($options->getOpt('verbose'), $options->getOpt('filter', ''), $options->getOpt('no-remote'));
                 break;
             case 'search':
                 $ret = $this->cmdSearch(
@@ -253,14 +256,18 @@ class cli_plugin_extension extends CLIPlugin
     /**
      * @param bool $showdetails
      * @param string $filter
+     * @param bool $noremote
      * @return int
      * @throws Exception
      */
-    protected function cmdList($showdetails, $filter)
+    protected function cmdList($showdetails, $filter, $noremote)
     {
         $extensions = (new Local())->getExtensions();
-        // initialize remote data in one go
-        Repository::getInstance()->initExtensions(array_keys($extensions));
+
+        if (! $noremote) {
+            // initialize remote data in one go
+            Repository::getInstance()->initExtensions(array_keys($extensions));
+        }
 
         $this->listExtensions($extensions, $showdetails, $filter);
         return 0;
@@ -272,17 +279,18 @@ class cli_plugin_extension extends CLIPlugin
      * @param Extension[] $list
      * @param bool $details display details
      * @param string $filter filter for this status
+     * @param bool $noremote whether to contact the remote repository
      * @throws Exception
      * @todo break into smaller methods
      */
-    protected function listExtensions($list, $details, $filter = '')
+    protected function listExtensions($list, $details, $filter = '', $noremote = false)
     {
         $tr = new TableFormatter($this->colors);
         foreach ($list as $ext) {
             $status = '';
             if ($ext->isInstalled()) {
                 $date = $ext->getInstalledVersion();
-                $avail = $ext->getLastUpdate();
+                $avail = $noremote ? null : $ext->getLastUpdate();
                 $status = 'i';
                 if ($avail && $avail > $date) {
                     $vcolor = Colors::C_RED;

--- a/lib/plugins/extension/cli.php
+++ b/lib/plugins/extension/cli.php
@@ -47,7 +47,13 @@ class cli_plugin_extension extends CLIPlugin
         $options->registerCommand('list', 'List installed extensions');
         $options->registerOption('verbose', 'Show detailed extension information', 'v', false, 'list');
         $options->registerOption('filter', 'Filter by this status', 'f', 'status', 'list');
-        $options->registerOption('no-remote', 'Don\'t contact the plugin repository; this means most issues won\'t be checked', 'n', false, 'list');
+        $options->registerOption(
+            'no-remote',
+            'Don\'t contact the plugin repository; this means most issues won\'t be checked',
+            'n',
+            false,
+            'list'
+        );
 
         // upgrade
         $options->registerCommand('upgrade', 'Update all installed extensions to their latest versions');

--- a/lib/plugins/extension/cli.php
+++ b/lib/plugins/extension/cli.php
@@ -305,7 +305,7 @@ class cli_plugin_extension extends CLIPlugin
                     $vcolor = null;
                 }
                 if ($ext->isGitControlled()) $status = 'g';
-                if ($ext->isBundled()) {
+                if ($noremote ? $ext->isBundledNoRemote() : $ext->isBundled()) {
                     $status = 'b';
                     $date = '<bundled>';
                     $vcolor = null;

--- a/lib/plugins/extension/cli.php
+++ b/lib/plugins/extension/cli.php
@@ -89,7 +89,11 @@ class cli_plugin_extension extends CLIPlugin
 
         switch ($options->getCmd()) {
             case 'list':
-                $ret = $this->cmdList($options->getOpt('verbose'), $options->getOpt('filter', ''), $options->getOpt('no-remote'));
+                $ret = $this->cmdList(
+                    $options->getOpt('verbose'),
+                    $options->getOpt('filter', ''),
+                    $options->getOpt('no-remote'),
+                );
                 break;
             case 'search':
                 $ret = $this->cmdSearch(

--- a/lib/plugins/extension/cli.php
+++ b/lib/plugins/extension/cli.php
@@ -302,7 +302,7 @@ class cli_plugin_extension extends CLIPlugin
                 } elseif ($avail && $avail <= $date) {
                     $vcolor = Colors::C_GREEN;
                 } else {
-                    // No color change if status unknown
+                    $vcolor = null;
                 }
                 if ($ext->isGitControlled()) $status = 'g';
                 if ($ext->isBundled()) {
@@ -326,7 +326,7 @@ class cli_plugin_extension extends CLIPlugin
                 continue;
             }
 
-            $notices = Notice::list($ext);
+            $notices = $noremote ? Notice::listNoRemote($ext) : Notice::list($ext);
             if ($notices[Notice::SECURITY]) $status .= Notice::symbol(Notice::SECURITY);
             if ($notices[Notice::ERROR]) $status .= Notice::symbol(Notice::ERROR);
             if ($notices[Notice::WARNING]) $status .= Notice::symbol(Notice::WARNING);

--- a/lib/plugins/extension/cli.php
+++ b/lib/plugins/extension/cli.php
@@ -299,8 +299,10 @@ class cli_plugin_extension extends CLIPlugin
                 if ($avail && $avail > $date) {
                     $vcolor = Colors::C_RED;
                     $status .= 'u';
-                } else {
+                } elseif ($avail && $avail <= $date) {
                     $vcolor = Colors::C_GREEN;
+                } else {
+                    // No color change if status unknown
                 }
                 if ($ext->isGitControlled()) $status = 'g';
                 if ($ext->isBundled()) {


### PR DESCRIPTION
Closes #4737.

I've tried to keep the changes minimal, so all the logic has gone into `cli.php`, and the Extension and Notice classes have just gained a few methods to query without using the remote repository, which can be called by the CLI.

Let me know if you'd prefer different naming for the option.