### PR TITLE
fix(css): keep toolbar picker and copy button above/within content

### DIFF
--- a/lib/tpl/dokuwiki/css/_edit.css
+++ b/lib/tpl/dokuwiki/css/_edit.css
@@ -39,6 +39,7 @@ div.picker {
     border: 1px solid @ini_border;
     background-color: @ini_background_alt;
     color: inherit;
+    z-index: 100;
 }
 /* picker for headlines */
 div.picker.pk_hl {

--- a/lib/tpl/dokuwiki/css/content.less
+++ b/lib/tpl/dokuwiki/css/content.less
@@ -176,13 +176,39 @@
     .code-copy-btn {
         opacity: 0;
     }
+}
 
-    &:hover,
-    &:focus {
-        .code-copy-btn {
-            opacity: 1;
-        }
-    }
+/* give the copy button a stable grid cell so it can stick to the scrollport edge */
+.dokuwiki pre.code,
+.dokuwiki pre.file {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto 1fr;
+    align-items: start;
+}
+
+/* keep the copy button pinned to the inline-end while the code scrolls horizontally */
+.dokuwiki .file > .code-copy-btn,
+.dokuwiki .code > .code-copy-btn {
+    position: sticky;
+    top: 0.25em;
+    right: 0.25em;
+    grid-column: 2;
+    grid-row: 1;
+}
+
+.dokuwiki .file:hover .code-copy-btn,
+.dokuwiki .code:hover .code-copy-btn,
+.dokuwiki .file:focus .code-copy-btn,
+.dokuwiki .code:focus .code-copy-btn {
+    opacity: 1;
+}
+
+/* pin the copy button to the inline-end in RTL (overrides lib/styles/screen.css) */
+[dir=rtl] .dokuwiki .file > .code-copy-btn,
+[dir=rtl] .dokuwiki .code > .code-copy-btn {
+    right: unset;
+    left: 0.25em;
 }
 
 /*____________ JS popup ____________*/


### PR DESCRIPTION
Fixes #4690 and #4729

- The editor toolbar picker popups had no z-index, so tall popups rendered underneath page footer elements. `div.picker` now uses the same stacking level as the template's search overlays (`z-index: 100`).
- The copy-to-clipboard button on code and file blocks was positioned absolutely, so it scrolled away with horizontally overflowing content. It is now `position: sticky` inside a dedicated grid cell on the `<pre>`, keeping it pinned to the inline-end of the block while its content scrolls, with an RTL override.

Both changes are CSS-only in the default template.
