### PR TITLE
fix(css): keep toolbar picker popups above page footer

### DIFF
--- a/lib/tpl/dokuwiki/css/_edit.css
+++ b/lib/tpl/dokuwiki/css/_edit.css
@@ -39,6 +39,9 @@ div.picker {
     border: 1px solid @ini_border;
     background-color: @ini_background_alt;
     color: inherit;
+    /* same stacking level as the search suggestion dropdown (css/_search.less),
+       so the picker isn't painted underneath later page content such as the footer */
+    z-index: 100;
 }
 /* picker for headlines */
 div.picker.pk_hl {


### PR DESCRIPTION
Fixes #4690

Split out of #4746 per review — this PR only contains the picker z-index fix; the copy-button fix moved to a separate PR.

`div.picker` (editor toolbar popups such as the link wizard) had no stacking context, so tall popups could render underneath page footer elements.

Re: the review question on whether `z-index: 100` is arbitrary — it isn't. `lib/tpl/dokuwiki/css/_search.less` already uses `z-index: 100` for the search suggestion dropdown, which faces the same problem: a toolbar-adjacent popup that needs to paint above later page content. I've added a comment in the CSS pointing at that precedent so it's not a bare magic number.

CSS-only change in the default template, no other z-index values in the toolbar/edit CSS apply to this kind of popup-above-content case (the others — 10, 20, 1, 0 — are used for local stacking within nested components, not for "float above later content").