### PR TITLE
fix(css): keep code-block copy button visible during horizontal scroll

### DIFF
--- a/lib/styles/screen.css
+++ b/lib/styles/screen.css
@@ -94,16 +94,23 @@ div.notify {
     right: -99999em !important;
 }
 
-/* copy to clipboard button on code blocks */
+/* copy to clipboard button on code blocks
+   uses a dedicated grid cell so the button can stick to the scrollport edge
+   instead of scrolling away with horizontally overflowing content */
 .dokuwiki .code,
 .dokuwiki .file {
-    position: relative;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto 1fr;
+    align-items: start;
 }
 
 .dokuwiki .code-copy-btn {
-    position: absolute;
+    position: sticky;
     top: 0.25em;
     right: 0.25em;
+    grid-column: 2;
+    grid-row: 1;
 }
 
 [dir=rtl] .dokuwiki .code-copy-btn {

--- a/lib/tpl/dokuwiki/css/content.less
+++ b/lib/tpl/dokuwiki/css/content.less
@@ -176,39 +176,13 @@
     .code-copy-btn {
         opacity: 0;
     }
-}
 
-/* give the copy button a stable grid cell so it can stick to the scrollport edge */
-.dokuwiki pre.code,
-.dokuwiki pre.file {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    grid-template-rows: auto 1fr;
-    align-items: start;
-}
-
-/* keep the copy button pinned to the inline-end while the code scrolls horizontally */
-.dokuwiki .file > .code-copy-btn,
-.dokuwiki .code > .code-copy-btn {
-    position: sticky;
-    top: 0.25em;
-    right: 0.25em;
-    grid-column: 2;
-    grid-row: 1;
-}
-
-.dokuwiki .file:hover .code-copy-btn,
-.dokuwiki .code:hover .code-copy-btn,
-.dokuwiki .file:focus .code-copy-btn,
-.dokuwiki .code:focus .code-copy-btn {
-    opacity: 1;
-}
-
-/* pin the copy button to the inline-end in RTL (overrides lib/styles/screen.css) */
-[dir=rtl] .dokuwiki .file > .code-copy-btn,
-[dir=rtl] .dokuwiki .code > .code-copy-btn {
-    right: unset;
-    left: 0.25em;
+    &:hover,
+    &:focus {
+        .code-copy-btn {
+            opacity: 1;
+        }
+    }
 }
 
 /*____________ JS popup ____________*/

--- a/lib/tpl/dokuwiki/css/content.less
+++ b/lib/tpl/dokuwiki/css/content.less
@@ -176,13 +176,39 @@
     .code-copy-btn {
         opacity: 0;
     }
+}
 
-    &:hover,
-    &:focus {
-        .code-copy-btn {
-            opacity: 1;
-        }
-    }
+/* give the copy button a stable grid cell so it can stick to the scrollport edge */
+.dokuwiki pre.code,
+.dokuwiki pre.file {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto 1fr;
+    align-items: start;
+}
+
+/* keep the copy button pinned to the inline-end while the code scrolls horizontally */
+.dokuwiki .file > .code-copy-btn,
+.dokuwiki .code > .code-copy-btn {
+    position: sticky;
+    top: 0.25em;
+    right: 0.25em;
+    grid-column: 2;
+    grid-row: 1;
+}
+
+.dokuwiki .file:hover .code-copy-btn,
+.dokuwiki .code:hover .code-copy-btn,
+.dokuwiki .file:focus .code-copy-btn,
+.dokuwiki .code:focus .code-copy-btn {
+    opacity: 1;
+}
+
+/* pin the copy button to the inline-end in RTL (overrides lib/styles/screen.css) */
+[dir=rtl] .dokuwiki .file > .code-copy-btn,
+[dir=rtl] .dokuwiki .code > .code-copy-btn {
+    right: unset;
+    left: 0.25em;
 }
 
 /*____________ JS popup ____________*/


### PR DESCRIPTION
Fixes #4729

Split out of #4746 per review — this PR only contains the copy-button fix; the toolbar picker z-index fix moved to a separate PR (#4748).

The copy-to-clipboard button on code/file blocks was `position: absolute`, so it scrolled out of view together with horizontally overflowing content. This gives `<pre>` a dedicated grid cell for the button and makes it `position: sticky`, pinned to the inline-end of the block while the code scrolls underneath it, with an RTL override.

CSS-only change in the default template.