### PR TITLE
Fix link to Media Manager when the current page is in the root namespace

### DIFF
--- a/inc/Menu/Item/Media.php
+++ b/inc/Menu/Item/Media.php
@@ -16,6 +16,6 @@ class Media extends AbstractItem
         parent::__construct();
 
         $this->svg = DOKU_INC . 'lib/images/menu/folder-multiple-image.svg';
-        $this->params['ns'] = getNS($ID);
+        $this->params['ns'] = (string)getNS($ID);
     }
 }

--- a/inc/Menu/Item/MediaManager.php
+++ b/inc/Menu/Item/MediaManager.php
@@ -23,6 +23,6 @@ class MediaManager extends AbstractItem
 
         $this->svg = DOKU_INC . 'lib/images/menu/11-mediamanager_folder-image.svg';
         $this->type = 'mediaManager';
-        $this->params = ['ns' => $imgNS, 'image' => $IMG, 'do' => 'media'];
+        $this->params = ['ns' => (string)$imgNS, 'image' => $IMG, 'do' => 'media'];
     }
 }

--- a/inc/Ui/Media/DisplayRow.php
+++ b/inc/Ui/Media/DisplayRow.php
@@ -32,7 +32,7 @@ class DisplayRow extends DisplayTile
             'alt="' . $lang['mediaview'] . '" title="' . $lang['mediaview'] . '" class="btn" /></a>';
 
         // mediamanager button
-        $link = wl('', ['do' => 'media', 'image' => $id, 'ns' => getNS($id)]);
+        $link = wl('', ['do' => 'media', 'image' => $id, 'ns' => (string)getNS($id)]);
         echo ' <a href="' . $link . '" target="_blank"><img src="' . DOKU_BASE . 'lib/images/mediamanager.png" ' .
             'alt="' . $lang['btn_media'] . '" title="' . $lang['btn_media'] . '" class="btn" /></a>';
 

--- a/inc/media.php
+++ b/inc/media.php
@@ -1452,6 +1452,7 @@ function media_managerURL($params = false, $amp = '&amp;', $abs = false, $params
     }
 
     if ($params) {
+        if (isset($params['ns'])) { $params['ns'] = (string)$params['ns']; }
         $gets = $params + $gets;
     }
     unset($gets['id']);


### PR DESCRIPTION
The root namespace value for `getNS()` is `false`, which is converted to "0" by `http_build_query()` resulting in the unexpected creation of a new "0" namespace when uploading files.

Cast the namespace value to a string so that `false` becomes an empty string before building the URL.