### PR TITLE
fix(info): tolerate plugins with incomplete getInfo() data

### DIFF
--- a/_test/tests/MailUtilsTest.php
+++ b/_test/tests/MailUtilsTest.php
@@ -165,6 +165,19 @@ class MailUtilsTest extends \DokuWikiTest
         }
     }
 
+    /**
+     * A missing address must degrade to an empty string rather than a TypeError.
+     */
+    public function testObfuscateNull(): void
+    {
+        global $conf;
+        foreach (['none', 'visible', 'hex'] as $mode) {
+            $conf['mailguard'] = $mode;
+            $this->assertEquals('', MailUtils::obfuscate(null), "obfuscate/$mode");
+            $this->assertEquals('', MailUtils::obfuscateUrl(null), "obfuscateUrl/$mode");
+        }
+    }
+
     // endregion
     // region isValid()
 

--- a/bin/plugin.php
+++ b/bin/plugin.php
@@ -79,7 +79,7 @@ class PluginCLI extends CLI
 
                 echo $tf->format(
                     [2, '30%', '*'],
-                    ['', $name, $info['desc']],
+                    ['', $name, $info['desc'] ?? ''],
                     ['', Colors::C_CYAN, '']
                 );
             }

--- a/inc/Extension/AdminPlugin.php
+++ b/inc/Extension/AdminPlugin.php
@@ -24,7 +24,7 @@ abstract class AdminPlugin extends Plugin
         $menutext = $this->getLang('menu');
         if (!$menutext) {
             $info = $this->getInfo();
-            $menutext = $info['name'] . ' ...';
+            $menutext = ($info['name'] ?? $this->getPluginName()) . ' ...';
         }
         return $menutext;
     }

--- a/inc/MailUtils.php
+++ b/inc/MailUtils.php
@@ -44,14 +44,14 @@ class MailUtils
      * verbatim and is never run through the [at]/[dot]/[dash] substitution,
      * so dots and dashes inside body/subject values stay intact.
      *
-     * @param string $email raw email address, optionally followed by ?query
-     * @return string HTML-text-safe representation
+     * @param string|null $email raw email address, optionally followed by ?query
+     * @return string HTML-text-safe representation, empty for a null address
      */
-    public static function obfuscate(string $email): string
+    public static function obfuscate(?string $email): string
     {
         global $conf;
 
-        [$addr, $query] = sexplode('?', $email, 2);
+        [$addr, $query] = sexplode('?', $email ?? '', 2);
         $out = self::obfuscateAddress($addr);
         // 'hex' output is already pure ASCII numeric entities → HTML-safe.
         // For 'none'/'visible' the address half still needs HTML escaping.
@@ -75,14 +75,15 @@ class MailUtils
      * preserved verbatim with only HTML-attribute escaping applied, so mail
      * clients receive correct subject/body separators.
      *
-     * @param string $email raw email address, optionally followed by ?query
-     * @return string HTML-attribute-safe URL fragment (without 'mailto:' prefix)
+     * @param string|null $email raw email address, optionally followed by ?query
+     * @return string HTML-attribute-safe URL fragment (without 'mailto:' prefix),
+     *                empty for a null address
      */
-    public static function obfuscateUrl(string $email): string
+    public static function obfuscateUrl(?string $email): string
     {
         global $conf;
 
-        [$addr, $query] = sexplode('?', $email, 2);
+        [$addr, $query] = sexplode('?', $email ?? '', 2);
         $addr = self::obfuscateAddress($addr);
         if ($conf['mailguard'] === 'visible') {
             $addr = rawurlencode($addr);

--- a/lib/plugins/config/core/Setting/SettingRenderer.php
+++ b/lib/plugins/config/core/Setting/SettingRenderer.php
@@ -27,7 +27,7 @@ class SettingRenderer extends SettingMultichoice
                 $this->choices[] = $plugin;
 
                 $info = $renderer->getInfo();
-                $this->prompts[$plugin] = $info['name'];
+                $this->prompts[$plugin] = $info['name'] ?? $plugin;
             }
         }
 

--- a/lib/plugins/info/syntax.php
+++ b/lib/plugins/info/syntax.php
@@ -118,18 +118,18 @@ class syntax_plugin_info extends SyntaxPlugin
 
         // list them
         $renderer->listu_open();
-        foreach ($plginfo as $info) {
+        foreach ($plginfo as $name => $info) {
             $renderer->listitem_open(1);
             $renderer->listcontent_open();
-            $renderer->externallink($info['url'], $info['name']);
+            $renderer->externallink($info['url'] ?? '', $info['name'] ?? $name);
             $renderer->cdata(' ');
             $renderer->emphasis_open();
-            $renderer->cdata($info['date']);
+            $renderer->cdata($info['date'] ?? '');
             $renderer->emphasis_close();
             $renderer->cdata(' ' . $lang['by'] . ' ');
-            $renderer->emaillink($info['email'], $info['author']);
+            $renderer->emaillink($info['email'] ?? '', $info['author'] ?? '');
             $renderer->linebreak();
-            $renderer->cdata($info['desc']);
+            $renderer->cdata($info['desc'] ?? '');
             $renderer->listcontent_close();
             $renderer->listitem_close();
         }
@@ -154,10 +154,11 @@ class syntax_plugin_info extends SyntaxPlugin
             $methods = $po->getMethods();
             $info = $po->getInfo();
 
-            $hid = $this->addToToc($info['name'], 2, $renderer);
-            $doc = '<h2><a name="' . $hid . '" id="' . $hid . '">' . hsc($info['name']) . '</a></h2>';
+            $name = $info['name'] ?? $p;
+            $hid = $this->addToToc($name, 2, $renderer);
+            $doc = '<h2><a name="' . $hid . '" id="' . $hid . '">' . hsc($name) . '</a></h2>';
             $doc .= '<div class="level2">';
-            $doc .= '<p>' . strtr(hsc($info['desc']), ["\n" => "<br />"]) . '</p>';
+            $doc .= '<p>' . strtr(hsc($info['desc'] ?? ''), ["\n" => "<br />"]) . '</p>';
             $doc .= '<pre class="code">$' . $p . " = plugin_load('helper', '" . $p . "');</pre>";
             $doc .= '</div>';
             foreach ($methods as $method) {


### PR DESCRIPTION
A plugin may override getInfo() and return an array that lacks some of the keys PluginTrait guarantees. The info plugin read those keys directly, so a missing 'email' reached MailUtils::obfuscate() and its string type declaration turned the whole page into a fatal TypeError. The obfuscate() before 73dc0a891 had no type declaration and rendered an empty address instead.

All places that read foreign getInfo() results now fall back to the plugin name or an empty string, and obfuscate()/obfuscateUrl() accept null again.

Closes #4759